### PR TITLE
update dev, tec, and second purchase

### DIFF
--- a/backend-python/shared_apis/order.py
+++ b/backend-python/shared_apis/order.py
@@ -1165,3 +1165,18 @@ def get_active_order_shoes():
         }
         res.append(obj)
     return res
+
+@order_bp.route("/order/gettechnicalconfirmstatus", methods=["GET"])
+def get_technical_confirm_status():
+    order_id = request.args.get("orderid")
+    order_shoe_status = (
+        db.session.query(Order, OrderShoe, OrderShoeStatus)
+        .join(OrderShoe, OrderShoe.order_id == Order.order_id)
+        .join(OrderShoeStatus, OrderShoeStatus.order_shoe_id == OrderShoe.order_shoe_id)
+        .filter(Order.order_id == order_id)
+        .all()
+    )
+    for order, order_shoe, order_shoe_status in order_shoe_status:
+        if order_shoe_status.current_status == 9:
+            return jsonify({"status": "鞋型辅料材料规格尚未由技术部确认，请谨慎生成采购订单！"})
+    return jsonify({"status": "鞋型辅料材料规格已由技术部确认！"})

--- a/backend-python/technical/process_sheet_upload.py
+++ b/backend-python/technical/process_sheet_upload.py
@@ -347,7 +347,7 @@ def save_production_instruction():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "面料")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -461,7 +461,7 @@ def save_production_instruction():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "里料")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -575,7 +575,7 @@ def save_production_instruction():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "辅料")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -621,6 +621,11 @@ def save_production_instruction():
                 is_pre_purchase = (
                     material_data.get("isPurchase")
                     if material_data.get("isPurchase")
+                    else None
+                )
+                material_second_type = (
+                    material_data.get("materialDetailType")
+                    if material_data.get("materialDetailType")
                     else None
                 )
                 material_type = "A"
@@ -685,7 +690,7 @@ def save_production_instruction():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "底材")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -793,7 +798,7 @@ def save_production_instruction():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "底材")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1009,7 +1014,7 @@ def save_production_instruction():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "复合")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1019,7 +1024,7 @@ def save_production_instruction():
                             material_unit=material_data.get("unit"),
                             material_creation_date=datetime.datetime.now(),
                             material_type_id=material_type_id,
-                            material_category=0,
+                            material_category=1 if material_data.get("materialType") == "烫底" else 0,
                         )
                         db.session.add(material)
                         db.session.flush()
@@ -1457,7 +1462,7 @@ def edit_craft_sheet():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "面料")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1572,7 +1577,7 @@ def edit_craft_sheet():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "里料")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1687,7 +1692,7 @@ def edit_craft_sheet():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "辅料")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1733,6 +1738,11 @@ def edit_craft_sheet():
                 is_pre_purchase = (
                     material_data.get("isPurchase")
                     if material_data.get("isPurchase")
+                    else None
+                )
+                material_second_type = (
+                    material_data.get("materialDetailType")
+                    if material_data.get("materialDetailType")
                     else None
                 )
                 material_type = "A"
@@ -1798,7 +1808,7 @@ def edit_craft_sheet():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "底材")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1844,6 +1854,11 @@ def edit_craft_sheet():
                 is_pre_purchase = (
                     material_data.get("isPurchase")
                     if material_data.get("isPurchase")
+                    else None
+                )
+                material_second_type = (
+                    material_data.get("materialDetailType")
+                    if material_data.get("materialDetailType")
                     else None
                 )
                 material_type = "O"
@@ -1907,7 +1922,7 @@ def edit_craft_sheet():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "底材")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -1953,6 +1968,11 @@ def edit_craft_sheet():
                 is_pre_purchase = (
                     material_data.get("isPurchase")
                     if material_data.get("isPurchase")
+                    else None
+                )
+                material_second_type = (
+                    material_data.get("materialDetailType")
+                    if material_data.get("materialDetailType")
                     else None
                 )
                 material_type = "M"
@@ -2125,7 +2145,7 @@ def edit_craft_sheet():
                             supplier_id = supplier.supplier_id
                         material_type_id = (
                             db.session.query(MaterialType)
-                            .filter(MaterialType.material_type_name == "复合")
+                            .filter(MaterialType.material_type_name == material_data.get("materialType"))
                             .first()
                             .material_type_id
                         )
@@ -2135,7 +2155,7 @@ def edit_craft_sheet():
                             material_unit=material_data.get("unit"),
                             material_creation_date=datetime.datetime.now(),
                             material_type_id=material_type_id,
-                            material_category=0,
+                            material_category=1 if material_data.get("materialType") == "烫底" else 0,
                         )
                         db.session.add(material)
                         db.session.flush()
@@ -2171,6 +2191,11 @@ def edit_craft_sheet():
                 is_pre_purchase = (
                     material_data.get("isPurchase")
                     if material_data.get("isPurchase")
+                    else None
+                )
+                material_second_type = (
+                    material_data.get("materialDetailType")
+                    if material_data.get("materialDetailType")
                     else None
                 )
                 material_type = "H"
@@ -2310,6 +2335,30 @@ def issue_production_order():
             db.session.flush()
             second_bom_id = second_bom.bom_id
             for item in craft_sheet_items:
+                production_instruction_item = (
+                    db.session.query(ProductionInstructionItem)
+                    .filter(
+                        ProductionInstructionItem.production_instruction_item_id
+                        == item.production_instruction_item_id
+                    )
+                    .first()
+                )
+                if production_instruction_item:
+                    production_instruction_item.material_specification = item.material_specification
+                    production_instruction_item.craft_name = item.craft_name
+                    db.session.flush()
+                first_bom_item = (
+                    db.session.query(BomItem)
+                    .filter(
+                        BomItem.production_instruction_item_id
+                        == item.production_instruction_item_id,
+                        BomItem.bom_item_add_type == "0",
+                    ).first()
+                )
+                if first_bom_item:
+                    first_bom_item.material_specification = item.material_specification
+                    first_bom_item.craft_name = item.craft_name
+                    db.session.flush()
                 material_storage = (
                     db.session.query(MaterialStorage).filter(
                         MaterialStorage.order_shoe_id == order_shoe_id,

--- a/frontend/jiancheng/src/Pages/DevelopmentManager/views/ProductionOrderCreateView.vue
+++ b/frontend/jiancheng/src/Pages/DevelopmentManager/views/ProductionOrderCreateView.vue
@@ -251,7 +251,9 @@
                 :title="`投产指令单创建 ${newProductionInstructionId}`"
                 v-model="isProductionOrderCreateDialogVisible"
                 width="90%"
-                style="height: 700px; overflow-y: scroll"
+                :close-on-click-modal="false"
+                fullscreen
+                style="overflow-y: scroll"
             >
                 <el-descriptions title="投产指令单公用信息" border :column="2">
                     <el-descriptions-item label="本码">
@@ -374,19 +376,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -499,19 +504,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -623,19 +631,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -747,19 +758,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -871,19 +885,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1001,19 +1018,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1414,8 +1434,10 @@
             <el-dialog
                 :title="`编辑投产指令单 ${newProductionInstructionId}`"
                 v-model="isEditDialogVisible"
+                :close-on-click-modal="false"
                 width="90%"
-                style="height: 700px; overflow-y: scroll"
+                full-screen
+                style="overflow-y: scroll"
             >
                 <el-descriptions title="投产指令单公用信息" border :column="2">
                     <el-descriptions-item label="本码">
@@ -1538,19 +1560,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1665,19 +1690,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1758,6 +1786,7 @@
                                     :data="getMaterialDataByType('accessoryMaterialData')"
                                     border
                                     style="width: 100%"
+ 
                                 >
                                     <el-table-column type="index"></el-table-column>
                                     <el-table-column prop="materialType" label="材料类型" />
@@ -1790,19 +1819,22 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1886,24 +1918,6 @@
                                 >
                                     <el-table-column type="index"></el-table-column>
                                     <el-table-column prop="materialType" label="材料类型" />
-
-                                    <el-table-column prop="supplierName" label="厂家名称">
-                                        <template #default="scope">
-                                            <el-autocomplete
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
-                                        </template>
-                                    </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
                                             <el-select
@@ -1930,6 +1944,27 @@
                                             </el-select>
                                         </template>
                                     </el-table-column>
+                                    <el-table-column prop="supplierName" label="厂家名称">
+                                        <template #default="scope">
+                                            <el-select
+                                                v-if="
+                                                    scope !== undefined &&
+                                                    scope.row.manualSymbol === 1
+                                                "
+                                                v-model="scope.row.supplierName"
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
+                                        </template>
+                                    </el-table-column>
+
                                     <el-table-column prop="materialModel" label="材料型号">
                                         <template #default="scope">
                                             <el-input
@@ -1958,14 +1993,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
 
                                     <el-table-column prop="comment" label="备注">
                                         <template #default="scope">
@@ -2019,24 +2047,6 @@
                                 >
                                     <el-table-column type="index"></el-table-column>
                                     <el-table-column prop="materialType" label="材料类型" />
-
-                                    <el-table-column prop="supplierName" label="厂家名称">
-                                        <template #default="scope">
-                                            <el-autocomplete
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
-                                        </template>
-                                    </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
                                             <el-select
@@ -2063,6 +2073,27 @@
                                             </el-select>
                                         </template>
                                     </el-table-column>
+                                    <el-table-column prop="supplierName" label="厂家名称">
+                                        <template #default="scope">
+                                            <el-select
+                                                v-if="
+                                                    scope !== undefined &&
+                                                    scope.row.manualSymbol === 1
+                                                "
+                                                v-model="scope.row.supplierName"
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
+                                        </template>
+                                    </el-table-column>
+
                                     <el-table-column prop="materialModel" label="材料型号">
                                         <template #default="scope">
                                             <el-input
@@ -2091,14 +2122,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
 
                                     <el-table-column prop="comment" label="备注">
                                         <template #default="scope">
@@ -2158,24 +2182,6 @@
                                 >
                                     <el-table-column type="index"></el-table-column>
                                     <el-table-column prop="materialType" label="材料类型" />
-
-                                    <el-table-column prop="supplierName" label="厂家名称">
-                                        <template #default="scope">
-                                            <el-autocomplete
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
-                                        </template>
-                                    </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
                                             <el-select
@@ -2202,6 +2208,27 @@
                                             </el-select>
                                         </template>
                                     </el-table-column>
+                                    <el-table-column prop="supplierName" label="厂家名称">
+                                        <template #default="scope">
+                                            <el-select
+                                                v-if="
+                                                    scope !== undefined &&
+                                                    scope.row.manualSymbol === 1
+                                                "
+                                                v-model="scope.row.supplierName"
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
+                                        </template>
+                                    </el-table-column>
+
                                     <el-table-column prop="materialModel" label="材料型号">
                                         <template #default="scope">
                                             <el-input
@@ -2240,14 +2267,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="comment" label="备注">
                                         <template #default="scope">
                                             <el-input
@@ -2401,7 +2421,8 @@ export default {
                 shoeTypeId: '',
                 color: ''
             },
-            materialNameOptions: []
+            materialNameOptions: [],
+            supplierNameOptions: [],
         }
     },
     async mounted() {
@@ -2410,6 +2431,7 @@ export default {
         this.getAllShoeListInfo()
         this.getAllDepartmentOptions()
         this.getAllMaterialName()
+        this.querySupplierNames()
     },
     computed: {
         uploadHeaders() {
@@ -2425,6 +2447,12 @@ export default {
     methods: {
         filterByTypes(options, types) {
             return options.filter((option) => types.includes(option.type))
+        },
+        async querySupplierNames() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/logistics/allsuppliers`
+            )
+            this.supplierNameOptions = response.data
         },
         async getAllDepartmentOptions() {
             const response = await axios.get(`${this.$apiBaseUrl}/general/getalldepartments`)
@@ -3221,25 +3249,6 @@ export default {
                 await axios
                     .get(
                         `${this.$apiBaseUrl}/devproductionorder/getautofinishedmaterialname?materialName=${queryString}`
-                    )
-                    .then((response) => {
-                        const suggestions = response.data.map((item) => ({
-                            value: item.name
-                        }))
-                        callback(suggestions)
-                    })
-                    .catch((error) => {
-                        console.error('Failed to fetch material names:', error)
-                    })
-            } else {
-                callback([])
-            }
-        },
-        async querySupplierNames(queryString, callback) {
-            if (queryString.trim()) {
-                await axios
-                    .get(
-                        `${this.$apiBaseUrl}/devproductionorder/getautofinishedsuppliername?supplierName=${queryString}`
                     )
                     .then((response) => {
                         const suggestions = response.data.map((item) => ({

--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/SecondOrderBOMView.vue
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/SecondOrderBOMView.vue
@@ -26,6 +26,9 @@
                         <el-descriptions-item label="订单预计截止日期" align="center">{{
                             orderData.deadlineTime
                         }}</el-descriptions-item>
+                        <el-descriptions-item label="调版及技术部确认状态" align="center">{{
+                            technicalConfirmStatus
+                        }}</el-descriptions-item>
                     </el-descriptions>
                 </el-col>
             </el-row>
@@ -683,7 +686,8 @@ export default {
             currentShoeSizeType: '',
             getShoeSizesName,
             shoeSizeColumns: [],
-            orderInfoVisible: true
+            orderInfoVisible: true,
+            technicalConfirmStatus: '未确认',
         }
     },
     async mounted() {
@@ -694,6 +698,7 @@ export default {
         this.$setAxiosToken()
         this.getOrderInfo()
         this.getAllShoeListInfo()
+        this.getTechnicalConfirmStatus()
     },
     computed: {
         processedBomTestData() {
@@ -722,6 +727,12 @@ export default {
         }
     },
     methods: {
+        async getTechnicalConfirmStatus() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/order/gettechnicalconfirmstatus?orderid=${this.orderId}`
+            )
+            this.technicalConfirmStatus = response.data.status
+        },
         translateProductionInstructionType(row) {
             const typeMap = {
                 S: '面料',

--- a/frontend/jiancheng/src/Pages/TechnologyDepartment/TechnicalManager/views/AdjustUpload.vue
+++ b/frontend/jiancheng/src/Pages/TechnologyDepartment/TechnicalManager/views/AdjustUpload.vue
@@ -278,7 +278,7 @@
                             type="textarea"
                             v-model="craftSheetDetail.cuttingSpecialCraft"
                             size="default"
-                            maxlength="150"
+                            maxlength="300"
                             autosize
                             show-word-limit
                         ></el-input>
@@ -288,7 +288,7 @@
                             type="textarea"
                             v-model="craftSheetDetail.sewingSpecialCraft"
                             size="default"
-                            maxlength="150"
+                            maxlength="300"
                             autosize
                             show-word-limit
                         ></el-input>
@@ -298,7 +298,7 @@
                             type="textarea"
                             v-model="craftSheetDetail.moldingSpecialCraft"
                             size="default"
-                            maxlength="200"
+                            maxlength="300"
                             autosize
                             show-word-limit
                         ></el-input>
@@ -352,7 +352,9 @@
                 title="材料工艺填写及更改页面"
                 v-model="isMaterialCraftVisDialog"
                 width="100%"
-                style="height: 750px; overflow-y: scroll"
+                :close-on-click-modal="false"
+                fullscreen
+                style="overflow-y: scroll"
             >
                 <el-tabs v-model="activeTab">
                     <!-- Generate tabs from backend-provided tabcolor array -->
@@ -394,36 +396,48 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.materialName"
-                                                size="default"
-                                                :fetch-suggestions="queryMaterialNames"
-                                                placeholder="输入材料名称"
-                                                @select="
+                                                filterable
+                                                @change="
                                                     handleMaterialNameSelect(scope.row, $event)
                                                 "
-                                            ></el-autocomplete>
+                                            >
+                                                <el-option
+                                                    v-for="item in filterByTypes(
+                                                        materialNameOptions,
+                                                        [1]
+                                                    )"
+                                                    :key="item.value"
+                                                    :value="item.value"
+                                                    :label="item.label"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -444,7 +458,6 @@
                                                 type="textarea"
                                                 autosize
                                                 size="default"
-                                                :disabled="scope.row.materialSource === 'P'"
                                             ></el-input>
                                         </template>
                                     </el-table-column>
@@ -477,18 +490,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="useDepart" label="使用工段">
                                         <template #default="scope">
                                             <el-select
@@ -561,36 +563,48 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.materialName"
-                                                size="default"
-                                                :fetch-suggestions="queryMaterialNames"
-                                                placeholder="输入材料名称"
-                                                @select="
+                                                filterable
+                                                @change="
                                                     handleMaterialNameSelect(scope.row, $event)
                                                 "
-                                            ></el-autocomplete>
+                                            >
+                                                <el-option
+                                                    v-for="item in filterByTypes(
+                                                        materialNameOptions,
+                                                        [2]
+                                                    )"
+                                                    :key="item.value"
+                                                    :value="item.value"
+                                                    :label="item.label"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -611,7 +625,6 @@
                                                 type="textarea"
                                                 autosize
                                                 size="default"
-                                                :disabled="scope.row.materialSource === 'P'"
                                             ></el-input>
                                         </template>
                                     </el-table-column>
@@ -644,18 +657,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="useDepart" label="使用工段">
                                         <template #default="scope">
                                             <el-select
@@ -714,6 +716,7 @@
                                 <el-table
                                     :data="getMaterialDataByType('accessoryMaterialData')"
                                     border
+                                    max-height="350"
                                     style="width: 100%"
                                 >
                                     <el-table-column type="index"></el-table-column>
@@ -727,36 +730,48 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.materialName"
-                                                size="default"
-                                                :fetch-suggestions="queryMaterialNames"
-                                                placeholder="输入材料名称"
-                                                @select="
+                                                filterable
+                                                @change="
                                                     handleMaterialNameSelect(scope.row, $event)
                                                 "
-                                            ></el-autocomplete>
+                                            >
+                                                <el-option
+                                                    v-for="item in filterByTypes(
+                                                        materialNameOptions,
+                                                        [3,5]
+                                                    )"
+                                                    :key="item.value"
+                                                    :value="item.value"
+                                                    :label="item.label"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -777,7 +792,6 @@
                                                 type="textarea"
                                                 autosize
                                                 size="default"
-                                                :disabled="scope.row.materialSource === 'P'"
                                             ></el-input>
                                         </template>
                                     </el-table-column>
@@ -810,18 +824,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="useDepart" label="使用工段">
                                         <template #default="scope">
                                             <el-select
@@ -893,36 +896,48 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.materialName"
-                                                size="default"
-                                                :fetch-suggestions="queryMaterialNames"
-                                                placeholder="输入材料名称"
-                                                @select="
+                                                filterable
+                                                @change="
                                                     handleMaterialNameSelect(scope.row, $event)
                                                 "
-                                            ></el-autocomplete>
+                                            >
+                                                <el-option
+                                                    v-for="item in filterByTypes(
+                                                        materialNameOptions,
+                                                        [7]
+                                                    )"
+                                                    :key="item.value"
+                                                    :value="item.value"
+                                                    :label="item.label"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -943,7 +958,6 @@
                                                 type="textarea"
                                                 autosize
                                                 size="default"
-                                                :disabled="scope.row.materialSource === 'P'"
                                             ></el-input>
                                         </template>
                                     </el-table-column>
@@ -976,18 +990,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="useDepart" label="使用工段">
                                         <template #default="scope">
                                             <el-select
@@ -1059,36 +1062,48 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.materialName"
-                                                size="default"
-                                                :fetch-suggestions="queryMaterialNames"
-                                                placeholder="输入材料名称"
-                                                @select="
+                                                filterable
+                                                @change="
                                                     handleMaterialNameSelect(scope.row, $event)
                                                 "
-                                            ></el-autocomplete>
+                                            >
+                                                <el-option
+                                                    v-for="item in filterByTypes(
+                                                        materialNameOptions,
+                                                        [7]
+                                                    )"
+                                                    :key="item.value"
+                                                    :value="item.value"
+                                                    :label="item.label"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1109,7 +1124,6 @@
                                                 type="textarea"
                                                 autosize
                                                 size="default"
-                                                :disabled="scope.row.materialSource === 'P'"
                                             ></el-input>
                                         </template>
                                     </el-table-column>
@@ -1142,18 +1156,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="useDepart" label="使用工段">
                                         <template #default="scope">
                                             <el-select
@@ -1225,36 +1228,48 @@
                                     </el-table-column>
                                     <el-table-column prop="supplierName" label="厂家名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.supplierName"
-                                                size="default"
-                                                :fetch-suggestions="querySupplierNames"
-                                                placeholder="输入厂家名称"
-                                                @select="
-                                                    handleSupplierNameSelect(scope.row, $event)
-                                                "
-                                            ></el-autocomplete>
+                                                filterable
+                                            >
+                                                <el-option
+                                                    v-for="item in supplierNameOptions"
+                                                    :key="item.supplierName"
+                                                    :value="item.supplierName"
+                                                    :label="item.supplierName"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialName" label="材料名称">
                                         <template #default="scope">
-                                            <el-autocomplete
+                                            <el-select
                                                 v-if="
                                                     scope !== undefined &&
                                                     scope.row.manualSymbol === 1
                                                 "
                                                 v-model="scope.row.materialName"
-                                                size="default"
-                                                :fetch-suggestions="queryMaterialNames"
-                                                placeholder="输入材料名称"
-                                                @select="
+                                                filterable
+                                                @change="
                                                     handleMaterialNameSelect(scope.row, $event)
                                                 "
-                                            ></el-autocomplete>
+                                            >
+                                                <el-option
+                                                    v-for="item in filterByTypes(
+                                                        materialNameOptions,
+                                                        [2,16]
+                                                    )"
+                                                    :key="item.value"
+                                                    :value="item.value"
+                                                    :label="item.label"
+                                                >
+                                                </el-option>
+                                            </el-select>
                                         </template>
                                     </el-table-column>
                                     <el-table-column prop="materialModel" label="材料型号">
@@ -1275,7 +1290,6 @@
                                                 type="textarea"
                                                 autosize
                                                 size="default"
-                                                :disabled="scope.row.materialSource === 'P'"
                                             ></el-input>
                                         </template>
                                     </el-table-column>
@@ -1308,18 +1322,7 @@
                                             ></el-input>
                                         </template>
                                     </el-table-column>
-                                    <el-table-column prop="unit" label="单位">
-                                        <template #default="scope">
-                                            <el-input
-                                                v-if="
-                                                    scope !== undefined &&
-                                                    scope.row.manualSymbol === 1
-                                                "
-                                                v-model="scope.row.unit"
-                                                size="default"
-                                            ></el-input>
-                                        </template>
-                                    </el-table-column>
+                                    <el-table-column prop="unit" label="单位"></el-table-column>
                                     <el-table-column prop="useDepart" label="使用工段">
                                         <template #default="scope">
                                             <el-select
@@ -1952,7 +1955,9 @@ export default {
             isCraftDialogVisible: false,
             syncMaterialButtonText: '同步该材料表格至所有颜色',
             inputCrafts: [], // 手动输入的工艺列表
-            currentRow: null // 当前编辑的行,
+            currentRow: null, // 当前编辑的行,
+            materialNameOptions: [],
+            supplierNameOptions: [],
         }
     },
     async mounted() {
@@ -1960,6 +1965,9 @@ export default {
         this.getOrderInfo()
         this.getAllShoeListInfo()
         this.getAllDepartmentOptions()
+        this.getAllMaterialList()
+        this.getAllMaterialName()
+        this.querySupplierNames()
         document.addEventListener('paste', this.handlePaste)
     },
     beforeUnmounted() {
@@ -1976,6 +1984,19 @@ export default {
         }
     },
     methods: {
+        filterByTypes(options, types) {
+            return options.filter((option) => types.includes(option.type))
+        },
+        async querySupplierNames() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/logistics/allsuppliers`
+            )
+            this.supplierNameOptions = response.data
+        },
+        async getAllMaterialName() {
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/getallmaterialname`)
+            this.materialNameOptions = response.data
+        },
         async pasteClipboardImage(target) {
             try {
                 // Access clipboard data
@@ -2559,6 +2580,26 @@ export default {
             return []
         },
         async editProductionInstrucion() {
+            for (const materialData of this.materialWholeData) {
+                for (const materialType of [
+                    'surfaceMaterialData',
+                    'insideMaterialData',
+                    'accessoryMaterialData',
+                    'outsoleMaterialData',
+                    'midsoleMaterialData',
+                    'hotsoleMaterialData'
+                ]) {
+                    for (const item of materialData[materialType]) {
+                        if (!item.supplierName || !item.materialName) {
+                            this.$message({
+                                type: 'error',
+                                message: '所有材料的供应商名称和材料名称不能为空'
+                            })
+                            return
+                        }
+                    }
+                }
+            }
             const loadingInstance = this.$loading({
                 lock: true,
                 text: '等待中，请稍后...',
@@ -2586,6 +2627,26 @@ export default {
             this.getAllShoeListInfo()
         },
         async saveProductionInstruction() {
+            for (const materialData of this.materialWholeData) {
+                for (const materialType of [
+                    'surfaceMaterialData',
+                    'insideMaterialData',
+                    'accessoryMaterialData',
+                    'outsoleMaterialData',
+                    'midsoleMaterialData',
+                    'hotsoleMaterialData'
+                ]) {
+                    for (const item of materialData[materialType]) {
+                        if (!item.supplierName || !item.materialName) {
+                            this.$message({
+                                type: 'error',
+                                message: '所有材料的供应商名称和材料名称不能为空'
+                            })
+                            return
+                        }
+                    }
+                }
+            }
             const loadingInstance = this.$loading({
                 lock: true,
                 text: '等待中，请稍后...',
@@ -2809,27 +2870,12 @@ export default {
                 callback([])
             }
         },
-        async querySupplierNames(queryString, callback) {
-            if (queryString.trim()) {
-                await axios
-                    .get(
-                        `${this.$apiBaseUrl}/devproductionorder/getautofinishedsuppliername?supplierName=${queryString}`
-                    )
-                    .then((response) => {
-                        const suggestions = response.data.map((item) => ({
-                            value: item.name
-                        }))
-                        callback(suggestions)
-                    })
-                    .catch((error) => {
-                        console.error('Failed to fetch material names:', error)
-                    })
-            } else {
-                callback([])
-            }
-        },
-        handleMaterialNameSelect(row, selectedItem) {
-            row.materialName = selectedItem.value
+        async handleMaterialNameSelect(row, selectedItem) {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/devproductionorder/getmaterialdetail?materialName=${row.materialName}`
+            )
+            row.unit = response.data.unit
+            row.materialType = response.data.materialType
         },
         handleSupplierNameSelect(row, selectedItem) {
             row.supplierName = selectedItem.value


### PR DESCRIPTION
开发部
1.将现有材料填写格式全部统一（原来底材开始不一样）
2.将对话框改为全屏显示，增大可视面积
3.厂家已改为纯选择模式

技术部
1.debug材料二级类型无法添加的问题
2.开放技术部修改材料规格的权限，并同步至投产指令单及一次bom
3.对话框修改至全屏，针对辅料过多的问题，修改辅料表格为滚动，其他不变
4.限制技术部填写名称或厂家空白无法保存
5.各车间要求字数限制由150上调至300，**注意更新本地数据库**
6.填写模式已更改至与开发部相同，但同步函数未更新（同步所有颜色）

总仓二次采购
针对目前技术部出现的修改规格问题，暂时为总仓二次采购订单创建增加提示栏。如技术部未下发工艺单，则给予信息提示，暂不在流程上限制下发