### PR TITLE
update logistic first purchase

### DIFF
--- a/backend-python/app_config.py
+++ b/backend-python/app_config.py
@@ -83,7 +83,9 @@ open_routes = [
     "/logistics/downloadassetzip",
     "/craftsheet/downloadcraftsheet",
     "/order/exportorder",
-    "/multiissue/downloadtotalpurchaseorder"
+    "/multiissue/downloadtotalpurchaseorder",
+    "/logistics/downloadlastpurchaseorders",
+    "/logistics/downloadpackagepurchaseorders",
 ]
 
 

--- a/backend-python/logistics/cut_model_api.py
+++ b/backend-python/logistics/cut_model_api.py
@@ -9,24 +9,45 @@ from operator import itemgetter
 from sqlalchemy.exc import SQLAlchemyError
 from itertools import groupby
 import os
+import json
 from general_document.purchase_divide_order import generate_excel_file
 from general_document.size_purchase_divide_order import generate_size_excel_file
 from constants import SHOESIZERANGE
 from event_processor import EventProcessor
 from file_locations import FILE_STORAGE_PATH, IMAGE_STORAGE_PATH, IMAGE_UPLOAD_PATH
+from business.batch_info_type import get_order_batch_type_helper
+from general_document.cutmodel_purchase_divide_order import generate_cut_model_excel_file
+import zipfile
 
 cut_model_api_bp = Blueprint("cut_model_api", __name__)
 
+
 @cut_model_api_bp.route("/logistics/getnewcutmodelpurchaseorderid", methods=["GET"])
-def get_new_last_purchase_order_id():
+def get_new_cut_model_purchase_order_id():
     department = "01"
     current_time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")[:-5]
     random_string = randomIdGenerater(6)
-    new_id = department + current_time_stamp + random_string + "C"
+    new_id = department + current_time_stamp + random_string + "L"
     return jsonify({"purchaseOrderRid": new_id})
 
+
+@cut_model_api_bp.route("/logistics/getcutmodelinfo", methods=["GET"])
+def get_cut_model_info():
+    order_id = request.args.get("orderid")
+    order_shoe = (
+        db.session.query(OrderShoe).filter(OrderShoe.order_id == order_id).first()
+    )
+    production_instruction = (
+        db.session.query(ProductionInstruction)
+        .filter(ProductionInstruction.order_shoe_id == order_shoe.order_shoe_id)
+        .first()
+    )
+    cut_model_type = production_instruction.cutting_model_type
+    return jsonify({"cutModelType": cut_model_type})
+
+
 @cut_model_api_bp.route("/logistics/searchcutmodelmaterialinfo", methods=["GET"])
-def search_last_material_info():
+def search_cut_model_material_info():
     materialModel = request.args.get("materialModel")
     material_storage = (
         db.session.query(SizeMaterialStorage, Material, MaterialType, Supplier)
@@ -34,7 +55,7 @@ def search_last_material_info():
         .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
         .join(Supplier, Material.material_supplier == Supplier.supplier_id)
         .filter(SizeMaterialStorage.size_material_model.ilike(f"%{materialModel}%"),
-                MaterialType.material_type_id == 11,)
+        MaterialType.material_type_id == 12,)
         .all()
     )
     material_storage_list = []
@@ -57,16 +78,16 @@ def search_last_material_info():
     return jsonify({"data": material_storage_list,"shoeSizeType": material_size_type})
 
 @cut_model_api_bp.route("/logistics/getcutmodelpurchaseorderitems", methods=["GET"])
-def get_last_purchase_order_items():
+def get_cut_model_purchase_order_items():
     order_id = request.args.get("orderid")
     purchase_order = (
         db.session.query(PurchaseOrder)
         .filter(PurchaseOrder.order_id == order_id,
-                PurchaseOrder.purchase_order_type == "C")
+                PurchaseOrder.purchase_order_type == "L")
         .first()
     )
     if not purchase_order:
-        return jsonify({"status": "error", "message": "Purchase order not found"}), 404
+        return jsonify({"purchaseOrderItems": [], "purchaseOrderId": None, "purchaseOrderRid": None})
     purchase_order_id = purchase_order.purchase_order_id
     purchase_order_rid = purchase_order.purchase_order_rid
     purchase_divide_orders = (
@@ -125,10 +146,10 @@ def get_last_purchase_order_items():
                     ],
                 }
             )
-    return jsonify({"status": "success", "purchaseOrderRid": purchase_order_rid, "purchaseOrderItems": purchase_order_items})
+    return jsonify({"status": "success", "purchaseOrderRid": purchase_order_rid, "purchaseOrderItems": purchase_order_items, "purchaseOrderId": purchase_order_id})
 
 @cut_model_api_bp.route("/logistics/newcutmodelpurchaseordersave", methods=["POST"])
-def new_last_purchase_order_save():
+def new_cut_model_purchase_order_save():
     try:
         sub_purchase_order_id = request.json.get("purchaseOrderRId")
         material_list = request.json.get("data")
@@ -155,7 +176,7 @@ def new_last_purchase_order_save():
             purchase_order_status=purchase_order_status,
         )
         # if it is order-related purchase
-        if purchase_order_type == "C":
+        if purchase_order_type == "L":
             purchase_order.order_id = order_id
 
         db.session.add(purchase_order)
@@ -270,7 +291,7 @@ def new_last_purchase_order_save():
         return jsonify({"status": "error", "message": str(e)}), 500
     
 @cut_model_api_bp.route("/logistics/editsavedcutmodelpurchaseorderitems", methods=["POST"])
-def edit_saved_last_purchase_order_items():
+def edit_saved_cut_model_purchase_order_items():
     try:
         sub_purchase_order_id = request.json.get("purchaseOrderRId")
         material_list = request.json.get("data")
@@ -430,3 +451,356 @@ def edit_saved_last_purchase_order_items():
         db.session.rollback()
         print(f"Error: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
+
+@cut_model_api_bp.route("/logistics/submitindividualpurchaseorders", methods=["POST"])
+def submit_purchase_divide_orders():
+    purchase_order_id = request.json.get("purchaseOrderId")
+    order_info = (
+        db.session.query(PurchaseOrder, Order)
+        .join(Order, PurchaseOrder.order_id == Order.order_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .first()
+    )
+    order_id = order_info.Order.order_id
+    order_rid = order_info.Order.order_rid
+    materials_data = []
+    query = (
+        db.session.query(
+            PurchaseDivideOrder,
+            PurchaseOrder,
+            AssetsPurchaseOrderItem,
+            Material,
+            MaterialType,
+            Supplier,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+    for (
+        purchase_divide_order,
+        purchase_order,
+        assets_purchase_order_item,
+        material,
+        material_type,
+        supplier,
+    ) in query:
+        current_time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")[:-5]
+        random_string = randomIdGenerater(6)
+        supplier_id_string = str(supplier.supplier_id).zfill(4)
+        total_purchase_order_rid = (
+            "T" + current_time_stamp + random_string + "L" + supplier_id_string
+        )
+        total_purchase_order = TotalPurchaseOrder(
+            total_purchase_order_rid=total_purchase_order_rid,
+            supplier_id=supplier.supplier_id,
+            create_date=datetime.datetime.now(),
+            total_purchase_order_remark="",
+            total_purchase_order_environmental_request="",
+            shipment_address="温州市瓯海区梧田工业基地镇南路8号（健诚集团）",
+            shipment_deadline="请在7-10日内交货",
+            total_purchase_order_status="2",
+        )
+        db.session.add(total_purchase_order)
+        db.session.flush()
+        purchase_divide_order.total_purchase_order_id = total_purchase_order.total_purchase_order_id
+        materials_data.append(
+            {
+                "supplier_name": supplier.supplier_name,
+                "material_name": material.material_name,
+                "model": assets_purchase_order_item.material_model or "",
+                "specification": assets_purchase_order_item.material_specification or "",
+                "purchase_amount": assets_purchase_order_item.purchase_amount,
+            }
+        )
+
+        material_id = assets_purchase_order_item.material_id
+        material_quantity = assets_purchase_order_item.purchase_amount
+        material_specification = assets_purchase_order_item.material_specification
+        material_model = assets_purchase_order_item.material_model
+        color = assets_purchase_order_item.color
+        remark = assets_purchase_order_item.remark
+        size_type = assets_purchase_order_item.size_type
+        craft_name = assets_purchase_order_item.craft_name
+        if purchase_divide_order.purchase_divide_order_type == "N":
+            material_storage = MaterialStorage(
+                order_id = order_id,
+                material_id=material_id,
+                estimated_inbound_amount=material_quantity,
+                actual_inbound_amount=0,
+                current_amount=0,
+                unit_price=0,
+                material_outsource_status="0",
+                material_model=material_model,
+                material_specification=material_specification,
+                material_storage_color=color,
+                total_purchase_order_id=total_purchase_order.total_purchase_order_id,
+                craft_name=craft_name,
+                actual_inbound_material_id=assets_purchase_order_item.inbound_material_id if assets_purchase_order_item.inbound_material_id else assets_purchase_order_item.material_id,
+                actual_inbound_unit=assets_purchase_order_item.inbound_unit if assets_purchase_order_item.inbound_unit else material.material_unit,
+            )
+            db.session.add(material_storage)
+        elif purchase_divide_order.purchase_divide_order_type == "S":
+            quantity_map = {}
+            for size in SHOESIZERANGE:
+                quantity_map[f"size_{size}_quantity"] = getattr(
+                    assets_purchase_order_item, f"size_{size}_purchase_amount"
+                )
+
+            size_material_storage = SizeMaterialStorage(
+                order_id=order_id,
+                material_id=material_id,
+                total_estimated_inbound_amount=material_quantity,
+                unit_price=0,
+                material_outsource_status="0",
+                size_material_model=material_model,
+                size_material_specification=material_specification,
+                size_material_color=color,
+                total_purchase_order_id=total_purchase_order.total_purchase_order_id,
+                craft_name=craft_name,
+            )
+            for size in SHOESIZERANGE:
+                setattr(
+                    size_material_storage,
+                    f"size_{size}_estimated_inbound_amount",
+                    quantity_map[f"size_{size}_quantity"],
+                )
+            db.session.add(size_material_storage)
+    purchase_order_status = "2"
+    db.session.query(PurchaseOrder).filter(
+        PurchaseOrder.purchase_order_id == purchase_order_id
+    ).update({"purchase_order_status": purchase_order_status})
+    db.session.flush()
+    purchase_divide_orders = (
+        db.session.query(
+            PurchaseDivideOrder,
+            AssetsPurchaseOrderItem,
+            PurchaseOrder,
+            Material,
+            Supplier,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+
+    # Dictionary to keep track of processed PurchaseDivideOrders
+    purchase_divide_order_dict = {}
+    size_purchase_divide_order_dict = {}
+    if (
+        os.path.exists(
+            os.path.join(FILE_STORAGE_PATH, order_rid)
+        )
+        == False
+    ):
+        os.mkdir(
+            os.path.join(FILE_STORAGE_PATH, order_rid)
+        )
+    customer_name = (
+        db.session.query(Customer)
+        .join(Order, Order.customer_id == Customer.customer_id)
+        .filter(Order.order_id == order_id)
+        .first()
+        .customer_name
+    )
+
+    # Iterate through the query results and group items by PurchaseDivideOrder
+    for (
+        purchase_divide_order,
+        assets_purchase_order_item,
+        purchase_order,
+        material,
+        supplier,
+    ) in purchase_divide_orders:
+        purchase_order_id = purchase_divide_order.purchase_divide_order_rid
+        if purchase_divide_order.purchase_divide_order_type == "N":
+            if purchase_order_id not in purchase_divide_order_dict:
+                purchase_divide_order_dict[purchase_order_id] = {
+                    "供应商": supplier.supplier_name,
+                    "日期": datetime.datetime.now().strftime("%Y-%m-%d"),
+                    "备注": purchase_divide_order.purchase_order_remark,
+                    "环保要求": purchase_divide_order.purchase_order_environmental_request,
+                    "发货地址": purchase_divide_order.shipment_address,
+                    "交货期限": purchase_divide_order.shipment_deadline,
+                    "客户名": customer_name,
+                    "订单信息": order_rid,
+                    "seriesData": [],
+                }
+
+            # Append the current PurchaseOrderItem to the 'seriesData' list of the relevant order
+            purchase_divide_order_dict[purchase_order_id]["seriesData"].append(
+                {
+                    "物品名称": (
+                        material.material_name
+                        + " "
+                        + (assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "")
+                        + " "
+                        + (
+                            assets_purchase_order_item.material_specification
+                            if assets_purchase_order_item.material_specification
+                            else ""
+                        )
+                        + " "
+                        + (assets_purchase_order_item.color if assets_purchase_order_item.color else "")
+                    ),
+                    "型号" : assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "",
+                    "类别" : material.material_name,
+                    "数量": assets_purchase_order_item.purchase_amount,
+                    "单位": material.material_unit,
+                    "备注": assets_purchase_order_item.remark,
+                    "用途说明": "",
+                }
+            )
+        elif purchase_divide_order.purchase_divide_order_type == "S":
+# 获取 order_size_table 并转换为字典
+            order_size_table = (
+                db.session.query(Order)
+                .filter(Order.order_id == order_id)
+                .first()
+                .order_size_table
+            )
+            if order_size_table:
+                order_size_table = json.loads(order_size_table)
+            else:
+                order_size_table = {}  # 确保是字典
+
+            # 获取 batch_info_type 信息
+            batch_info_type = (
+                db.session.query(BatchInfoType, Order)
+                .join(Order, Order.batch_info_type_id == BatchInfoType.batch_info_type_id)
+                .filter(Order.order_id == order_id)
+                .first()
+            )
+
+            # 1️⃣ 创建 "客人码" -> "实际尺码" 映射
+            customer_size_map = {}  # { "7.5": 34, "8.0": 35, "8.5": 36 }
+            for i in SHOESIZERANGE:
+                size_name = getattr(batch_info_type.BatchInfoType, f"size_{i}_name", None)
+                if size_name:
+                    customer_size_map[size_name] = i  # 例如 {"7.5": 34, "8.0": 35, "8.5": 36}
+
+            # 2️⃣ 确保 `order_size_table` 至少有 `客人码`
+            if "客人码" not in order_size_table or not order_size_table["客人码"]:
+                order_size_table["客人码"] = list(customer_size_map.keys())  # 从 batch_info_type 生成客人码
+
+            # 3️⃣ 根据 `material_name` 选择合适的尺码来源
+            if "大底" in material.material_name:
+                size_values = order_size_table.get("大底", order_size_table["客人码"])  # 兜底使用 `客人码`
+            elif "中底" in material.material_name:
+                size_values = order_size_table.get("中底", order_size_table["客人码"])
+            elif "楦头" in material.material_name:
+                size_values = order_size_table.get("楦头", order_size_table["客人码"])
+            else:
+                size_values = order_size_table["客人码"]
+            print(size_values)
+
+            # 4️⃣ 转换为实际尺码并构造最终的 obj
+            obj = {
+                "物品名称": (
+                    material.material_name
+                    + " "
+                    + (assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "")
+                    + " "
+                    + (
+                        assets_purchase_order_item.material_specification
+                        if assets_purchase_order_item.material_specification
+                        else ""
+                    )
+                    + " "
+                    + (assets_purchase_order_item._color if assets_purchase_order_item.color else "")
+                ),
+                "型号" : assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "",
+                "类别" : material.material_name,
+                "备注": assets_purchase_order_item.remark,
+            }
+            for index, size_value in enumerate(size_values):
+                customer_value = order_size_table["客人码"][index]
+                if customer_value in customer_size_map:
+                    actual_size = customer_size_map[customer_value]  # 例如 7.5 -> 34
+                    obj[size_value] = getattr(assets_purchase_order_item, f"size_{actual_size}_purchase_amount", 0)
+
+            # 5️⃣ 添加到 seriesData
+            if purchase_order_id not in size_purchase_divide_order_dict:
+                size_purchase_divide_order_dict[purchase_order_id] = {
+                    "供应商": supplier.supplier_name,
+                    "日期": datetime.datetime.now().strftime("%Y-%m-%d"),
+                    "备注": purchase_divide_order.purchase_order_remark,
+                    "客户名": customer_name,
+                    "环保要求": purchase_divide_order.purchase_order_environmental_request,
+                    "发货地址": purchase_divide_order.shipment_address,
+                    "交货期限": purchase_divide_order.shipment_deadline,
+                    "订单信息": order_rid,
+                    "seriesData": [],
+                }
+
+            size_purchase_divide_order_dict[purchase_order_id]["seriesData"].append(obj)
+            print(size_purchase_divide_order_dict)
+    customer_name = (
+        db.session.query(Order, Customer)
+        .join(Customer, Order.customer_id == Customer.customer_id)
+        .filter(Order.order_id == order_id)
+        .first()
+        .Customer.customer_name
+    )
+    generated_files = []
+    # Convert the dictionary to a list
+    template_path = os.path.join(FILE_STORAGE_PATH, "标准采购订单.xlsx")
+    size_template_path = os.path.join(FILE_STORAGE_PATH, "新标准采购订单尺码版.xlsx")
+    for purchase_order_id, data in purchase_divide_order_dict.items():
+        new_file_path = os.path.join(
+            FILE_STORAGE_PATH,
+            order_rid,
+            purchase_order_id + "_楦头采购订单_" + data["供应商"] + ".xlsx",
+        )
+        generate_excel_file(template_path, new_file_path, data)
+        generated_files.append(new_file_path)
+    shoe_size_names = get_order_batch_type_helper(order_id)
+    for purchase_order_id, data in size_purchase_divide_order_dict.items():
+        new_file_path = os.path.join(
+            FILE_STORAGE_PATH,
+            order_rid,
+            purchase_order_id + "_楦头采购订单_" + data["供应商"] + ".xlsx",
+        )
+        data["shoe_size_names"] = shoe_size_names
+        generate_cut_model_excel_file(
+                size_template_path, new_file_path, data
+            )
+        generated_files.append(new_file_path)
+    zip_file_path = os.path.join(
+        FILE_STORAGE_PATH,
+        order_rid,
+        "楦头采购订单.zip",
+    )
+    with zipfile.ZipFile(zip_file_path, "w") as zipf:
+        for file in generated_files:
+            # Extract purchase_order_id from the filename and check if it ends with 'F'
+            filename = os.path.basename(file)
+            purchase_order_id = filename.split("_")[0]  # Get the part before "_供应商"
+            if len(purchase_order_id) >= 5 and purchase_order_id[-5] == "L":
+                zipf.write(file, filename)  # Add the file to the zip
+    order = db.session.query(Order).filter(Order.order_id == order_id).first()
+    order.cutting_model_status = '2'
+    db.session.commit()
+    return jsonify({"status": "success"})
+    

--- a/backend-python/logistics/last_api.py
+++ b/backend-python/logistics/last_api.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, send_file
 import datetime
 from app_config import app, db
 from models import *
@@ -9,11 +9,15 @@ from operator import itemgetter
 from sqlalchemy.exc import SQLAlchemyError
 from itertools import groupby
 import os
+import json
 from general_document.purchase_divide_order import generate_excel_file
 from general_document.size_purchase_divide_order import generate_size_excel_file
 from constants import SHOESIZERANGE
 from event_processor import EventProcessor
 from file_locations import FILE_STORAGE_PATH, IMAGE_STORAGE_PATH, IMAGE_UPLOAD_PATH
+from business.batch_info_type import get_order_batch_type_helper
+from general_document.last_purchase_divide_order import generate_last_excel_file
+import zipfile
 
 last_api_bp = Blueprint("last_api", __name__)
 
@@ -83,7 +87,7 @@ def get_last_purchase_order_items():
         .first()
     )
     if not purchase_order:
-        return jsonify({"status": "error", "message": "Purchase order not found"}), 404
+        return jsonify({"purchaseOrderItems": [], "purchaseOrderId": None, "purchaseOrderRid": None})
     purchase_order_id = purchase_order.purchase_order_id
     purchase_order_rid = purchase_order.purchase_order_rid
     purchase_divide_orders = (
@@ -142,7 +146,7 @@ def get_last_purchase_order_items():
                     ],
                 }
             )
-    return jsonify({"status": "success", "purchaseOrderRid": purchase_order_rid, "purchaseOrderItems": purchase_order_items})
+    return jsonify({"status": "success", "purchaseOrderRid": purchase_order_rid, "purchaseOrderItems": purchase_order_items, "purchaseOrderId": purchase_order_id})
 
 @last_api_bp.route("/logistics/newlastpurchaseordersave", methods=["POST"])
 def new_last_purchase_order_save():
@@ -447,4 +451,473 @@ def edit_saved_last_purchase_order_items():
         db.session.rollback()
         print(f"Error: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
+    
+@last_api_bp.route("/logistics/getindividualpurchaseorders", methods=["GET"])
+def get_individual_purchase_orders():
+    purchase_order_id = request.args.get("purchaseOrderId")
+
+    # Fetch the data from the database
+    query = (
+        db.session.query(
+            PurchaseDivideOrder,
+            TotalPurchaseOrder,
+            PurchaseOrder,
+            AssetsPurchaseOrderItem,
+            Material,
+            MaterialType,
+            Supplier,
+        )
+        .outerjoin(
+            TotalPurchaseOrder,
+            PurchaseDivideOrder.total_purchase_order_id
+            == TotalPurchaseOrder.total_purchase_order_id,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+    print(query)
+
+    # Group the results by purchase_divide_order_rid
+    grouped_results = {}
+    for (
+        purchase_divide_order,
+        total_purchase_order,
+        purchase_order,
+        assets_purchase_order_item,
+        material,
+        material_type,
+        supplier,
+    ) in query:
+        divide_order_rid = purchase_divide_order.purchase_divide_order_rid
+        if divide_order_rid not in grouped_results:
+            if total_purchase_order:
+                if total_purchase_order.total_purchase_order_status == "1":
+                    purchase_divide_order_status = "已保存"
+                elif total_purchase_order.total_purchase_order_status == "2":
+                    purchase_divide_order_status = "已下发"
+                else:
+                    purchase_divide_order_status = "未处理"
+            else:
+                purchase_divide_order_status = "未处理"
+            grouped_results[divide_order_rid] = {
+                "purchaseDivideOrderId": divide_order_rid,
+                "purchaseOrderId": purchase_divide_order.purchase_order_id,
+                "supplierName": supplier.supplier_name,
+                "assetsItems": [],
+                "purchaseDivideOrderType": purchase_divide_order.purchase_divide_order_type,
+                "remark": purchase_divide_order.purchase_order_remark,
+                "evironmentalRequest": purchase_divide_order.purchase_order_environmental_request,
+                "shipmentAddress": purchase_divide_order.shipment_address,
+                "shipmentDeadline": purchase_divide_order.shipment_deadline,
+                "purchaseDivideOrderStatus": purchase_divide_order_status,
+            }
+
+        # Append the assets item details to the corresponding group
+        obj = {
+            "materialId": assets_purchase_order_item.material_id,
+            "materialType": material_type.material_type_name,
+            "materialName": material.material_name,
+            "materialModel": assets_purchase_order_item.material_model,
+            "materialSpecification": assets_purchase_order_item.material_specification,
+            "color": assets_purchase_order_item.color,
+            "unit": material.material_unit,
+            "purchaseAmount": assets_purchase_order_item.purchase_amount,
+            "remark": assets_purchase_order_item.remark,
+            "sizeType": assets_purchase_order_item.size_type,
+            
+        }
+        for size in SHOESIZERANGE:
+            obj[f"size{size}Amount"] = getattr(
+                assets_purchase_order_item, f"size_{size}_purchase_amount"
+            )
+        grouped_results[divide_order_rid]["assetsItems"].append(obj)
+
+    # Convert the grouped results to a list
+    result = list(grouped_results.values())
+
+    return jsonify(result)
+
+@last_api_bp.route("/logistics/submitindividualpurchaseorders", methods=["POST"])
+def submit_purchase_divide_orders():
+    purchase_order_id = request.json.get("purchaseOrderId")
+    order_info = (
+        db.session.query(PurchaseOrder, Order)
+        .join(Order, PurchaseOrder.order_id == Order.order_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .first()
+    )
+    order_id = order_info.Order.order_id
+    order_rid = order_info.Order.order_rid
+    materials_data = []
+    query = (
+        db.session.query(
+            PurchaseDivideOrder,
+            PurchaseOrder,
+            AssetsPurchaseOrderItem,
+            Material,
+            MaterialType,
+            Supplier,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+    for (
+        purchase_divide_order,
+        purchase_order,
+        assets_purchase_order_item,
+        material,
+        material_type,
+        supplier,
+    ) in query:
+        current_time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")[:-5]
+        random_string = randomIdGenerater(6)
+        supplier_id_string = str(supplier.supplier_id).zfill(4)
+        total_purchase_order_rid = (
+            "T" + current_time_stamp + random_string + "L" + supplier_id_string
+        )
+        total_purchase_order = TotalPurchaseOrder(
+            total_purchase_order_rid=total_purchase_order_rid,
+            supplier_id=supplier.supplier_id,
+            create_date=datetime.datetime.now(),
+            total_purchase_order_remark="",
+            total_purchase_order_environmental_request="",
+            shipment_address="温州市瓯海区梧田工业基地镇南路8号（健诚集团）",
+            shipment_deadline="请在7-10日内交货",
+            total_purchase_order_status="2",
+        )
+        db.session.add(total_purchase_order)
+        db.session.flush()
+        purchase_divide_order.total_purchase_order_id = total_purchase_order.total_purchase_order_id
+        materials_data.append(
+            {
+                "supplier_name": supplier.supplier_name,
+                "material_name": material.material_name,
+                "model": assets_purchase_order_item.material_model or "",
+                "specification": assets_purchase_order_item.material_specification or "",
+                "purchase_amount": assets_purchase_order_item.purchase_amount,
+            }
+        )
+
+        material_id = assets_purchase_order_item.material_id
+        material_quantity = assets_purchase_order_item.purchase_amount
+        material_specification = assets_purchase_order_item.material_specification
+        material_model = assets_purchase_order_item.material_model
+        color = assets_purchase_order_item.color
+        remark = assets_purchase_order_item.remark
+        size_type = assets_purchase_order_item.size_type
+        craft_name = assets_purchase_order_item.craft_name
+        if purchase_divide_order.purchase_divide_order_type == "N":
+            material_storage = MaterialStorage(
+                order_id = order_id,
+                material_id=material_id,
+                estimated_inbound_amount=material_quantity,
+                actual_inbound_amount=0,
+                current_amount=0,
+                unit_price=0,
+                material_outsource_status="0",
+                material_model=material_model,
+                material_specification=material_specification,
+                material_storage_color=color,
+                total_purchase_order_id=total_purchase_order.total_purchase_order_id,
+                craft_name=craft_name,
+                actual_inbound_material_id=assets_purchase_order_item.inbound_material_id if assets_purchase_order_item.inbound_material_id else assets_purchase_order_item.material_id,
+                actual_inbound_unit=assets_purchase_order_item.inbound_unit if assets_purchase_order_item.inbound_unit else material.material_unit,
+            )
+            db.session.add(material_storage)
+        elif purchase_divide_order.purchase_divide_order_type == "S":
+            quantity_map = {}
+            for size in SHOESIZERANGE:
+                quantity_map[f"size_{size}_quantity"] = getattr(
+                    assets_purchase_order_item, f"size_{size}_purchase_amount"
+                )
+
+            size_material_storage = SizeMaterialStorage(
+                order_id=order_id,
+                material_id=material_id,
+                total_estimated_inbound_amount=material_quantity,
+                unit_price=0,
+                material_outsource_status="0",
+                size_material_model=material_model,
+                size_material_specification=material_specification,
+                size_material_color=color,
+                total_purchase_order_id=total_purchase_order.total_purchase_order_id,
+                craft_name=craft_name,
+            )
+            for size in SHOESIZERANGE:
+                setattr(
+                    size_material_storage,
+                    f"size_{size}_estimated_inbound_amount",
+                    quantity_map[f"size_{size}_quantity"],
+                )
+            db.session.add(size_material_storage)
+    purchase_order_status = "2"
+    db.session.query(PurchaseOrder).filter(
+        PurchaseOrder.purchase_order_id == purchase_order_id
+    ).update({"purchase_order_status": purchase_order_status})
+    db.session.flush()
+    purchase_divide_orders = (
+        db.session.query(
+            PurchaseDivideOrder,
+            AssetsPurchaseOrderItem,
+            PurchaseOrder,
+            Material,
+            Supplier,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+
+    # Dictionary to keep track of processed PurchaseDivideOrders
+    purchase_divide_order_dict = {}
+    size_purchase_divide_order_dict = {}
+    if (
+        os.path.exists(
+            os.path.join(FILE_STORAGE_PATH, order_rid)
+        )
+        == False
+    ):
+        os.mkdir(
+            os.path.join(FILE_STORAGE_PATH, order_rid)
+        )
+    customer_name = (
+        db.session.query(Customer)
+        .join(Order, Order.customer_id == Customer.customer_id)
+        .filter(Order.order_id == order_id)
+        .first()
+        .customer_name
+    )
+
+    # Iterate through the query results and group items by PurchaseDivideOrder
+    for (
+        purchase_divide_order,
+        assets_purchase_order_item,
+        purchase_order,
+        material,
+        supplier,
+    ) in purchase_divide_orders:
+        purchase_order_id = purchase_divide_order.purchase_divide_order_rid
+        if purchase_divide_order.purchase_divide_order_type == "N":
+            if purchase_order_id not in purchase_divide_order_dict:
+                purchase_divide_order_dict[purchase_order_id] = {
+                    "供应商": supplier.supplier_name,
+                    "日期": datetime.datetime.now().strftime("%Y-%m-%d"),
+                    "备注": purchase_divide_order.purchase_order_remark,
+                    "环保要求": purchase_divide_order.purchase_order_environmental_request,
+                    "发货地址": purchase_divide_order.shipment_address,
+                    "交货期限": purchase_divide_order.shipment_deadline,
+                    "客户名": customer_name,
+                    "订单信息": order_rid,
+                    "seriesData": [],
+                }
+
+            # Append the current PurchaseOrderItem to the 'seriesData' list of the relevant order
+            purchase_divide_order_dict[purchase_order_id]["seriesData"].append(
+                {
+                    "物品名称": (
+                        material.material_name
+                        + " "
+                        + (assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "")
+                        + " "
+                        + (
+                            assets_purchase_order_item.material_specification
+                            if assets_purchase_order_item.material_specification
+                            else ""
+                        )
+                        + " "
+                        + (assets_purchase_order_item.color if assets_purchase_order_item.color else "")
+                    ),
+                    "型号" : assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "",
+                    "类别" : material.material_name,
+                    "数量": assets_purchase_order_item.purchase_amount,
+                    "单位": material.material_unit,
+                    "备注": assets_purchase_order_item.remark,
+                    "用途说明": "",
+                }
+            )
+        elif purchase_divide_order.purchase_divide_order_type == "S":
+# 获取 order_size_table 并转换为字典
+            order_size_table = (
+                db.session.query(Order)
+                .filter(Order.order_id == order_id)
+                .first()
+                .order_size_table
+            )
+            if order_size_table:
+                order_size_table = json.loads(order_size_table)
+            else:
+                order_size_table = {}  # 确保是字典
+
+            # 获取 batch_info_type 信息
+            batch_info_type = (
+                db.session.query(BatchInfoType, Order)
+                .join(Order, Order.batch_info_type_id == BatchInfoType.batch_info_type_id)
+                .filter(Order.order_id == order_id)
+                .first()
+            )
+
+            # 1️⃣ 创建 "客人码" -> "实际尺码" 映射
+            customer_size_map = {}  # { "7.5": 34, "8.0": 35, "8.5": 36 }
+            for i in SHOESIZERANGE:
+                size_name = getattr(batch_info_type.BatchInfoType, f"size_{i}_name", None)
+                if size_name:
+                    customer_size_map[size_name] = i  # 例如 {"7.5": 34, "8.0": 35, "8.5": 36}
+
+            # 2️⃣ 确保 `order_size_table` 至少有 `客人码`
+            if "客人码" not in order_size_table or not order_size_table["客人码"]:
+                order_size_table["客人码"] = list(customer_size_map.keys())  # 从 batch_info_type 生成客人码
+
+            # 3️⃣ 根据 `material_name` 选择合适的尺码来源
+            if "大底" in material.material_name:
+                size_values = order_size_table.get("大底", order_size_table["客人码"])  # 兜底使用 `客人码`
+            elif "中底" in material.material_name:
+                size_values = order_size_table.get("中底", order_size_table["客人码"])
+            elif "楦头" in material.material_name:
+                size_values = order_size_table.get("楦头", order_size_table["客人码"])
+            else:
+                size_values = order_size_table["客人码"]
+            print(size_values)
+
+            # 4️⃣ 转换为实际尺码并构造最终的 obj
+            obj = {
+                "物品名称": (
+                    material.material_name
+                    + " "
+                    + (assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "")
+                    + " "
+                    + (
+                        assets_purchase_order_item.material_specification
+                        if assets_purchase_order_item.material_specification
+                        else ""
+                    )
+                    + " "
+                    + (assets_purchase_order_item._color if assets_purchase_order_item.color else "")
+                ),
+                "型号" : assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "",
+                "类别" : material.material_name,
+                "备注": assets_purchase_order_item.remark,
+            }
+            for index, size_value in enumerate(size_values):
+                customer_value = order_size_table["客人码"][index]
+                if customer_value in customer_size_map:
+                    actual_size = customer_size_map[customer_value]  # 例如 7.5 -> 34
+                    obj[size_value] = getattr(assets_purchase_order_item, f"size_{actual_size}_purchase_amount", 0)
+
+            # 5️⃣ 添加到 seriesData
+            if purchase_order_id not in size_purchase_divide_order_dict:
+                size_purchase_divide_order_dict[purchase_order_id] = {
+                    "供应商": supplier.supplier_name,
+                    "日期": datetime.datetime.now().strftime("%Y-%m-%d"),
+                    "备注": purchase_divide_order.purchase_order_remark,
+                    "客户名": customer_name,
+                    "环保要求": purchase_divide_order.purchase_order_environmental_request,
+                    "发货地址": purchase_divide_order.shipment_address,
+                    "交货期限": purchase_divide_order.shipment_deadline,
+                    "订单信息": order_rid,
+                    "seriesData": [],
+                }
+
+            size_purchase_divide_order_dict[purchase_order_id]["seriesData"].append(obj)
+            print(size_purchase_divide_order_dict)
+    customer_name = (
+        db.session.query(Order, Customer)
+        .join(Customer, Order.customer_id == Customer.customer_id)
+        .filter(Order.order_id == order_id)
+        .first()
+        .Customer.customer_name
+    )
+    generated_files = []
+    # Convert the dictionary to a list
+    template_path = os.path.join(FILE_STORAGE_PATH, "标准采购订单.xlsx")
+    size_template_path = os.path.join(FILE_STORAGE_PATH, "新标准采购订单尺码版.xlsx")
+    for purchase_order_id, data in purchase_divide_order_dict.items():
+        new_file_path = os.path.join(
+            FILE_STORAGE_PATH,
+            order_rid,
+            purchase_order_id + "_楦头采购订单_" + data["供应商"] + ".xlsx",
+        )
+        generate_excel_file(template_path, new_file_path, data)
+        generated_files.append(new_file_path)
+    shoe_size_names = get_order_batch_type_helper(order_id)
+    for purchase_order_id, data in size_purchase_divide_order_dict.items():
+        new_file_path = os.path.join(
+            FILE_STORAGE_PATH,
+            order_rid,
+            purchase_order_id + "_楦头采购订单_" + data["供应商"] + ".xlsx",
+        )
+        data["shoe_size_names"] = shoe_size_names
+        generate_last_excel_file(
+                size_template_path, new_file_path, data
+            )
+        generated_files.append(new_file_path)
+    zip_file_path = os.path.join(
+        FILE_STORAGE_PATH,
+        order_rid,
+        "楦头采购订单.zip",
+    )
+    with zipfile.ZipFile(zip_file_path, "w") as zipf:
+        for file in generated_files:
+            # Extract purchase_order_id from the filename and check if it ends with 'F'
+            filename = os.path.basename(file)
+            purchase_order_id = filename.split("_")[0]  # Get the part before "_供应商"
+            if len(purchase_order_id) >= 5 and purchase_order_id[-5] == "L":
+                zipf.write(file, filename)  # Add the file to the zip
+    order = db.session.query(Order).filter(Order.order_id == order_id).first()
+    order.last_status = '2'
+    db.session.commit()
+    return jsonify({"status": "success"})
+
+@last_api_bp.route("/logistics/downloadlastpurchaseorders", methods=["GET"])
+def download_last_purchase_orders():
+    order_id = request.args.get("orderId")
+    order = db.session.query(Order).filter(Order.order_id == order_id).first()
+    order_rid = order.order_rid
+    zip_file_path = os.path.join(
+        FILE_STORAGE_PATH,
+        order_rid,
+        "楦头采购订单.zip",
+    )
+    return send_file(zip_file_path, as_attachment=True)
+
+@last_api_bp.route("/logistics/jumpoverlastpurchase", methods=["GET"])
+def jump_over_last_purchase():
+    order_id = request.args.get("orderId")
+    order = db.session.query(Order).filter(Order.order_id == order_id).first()
+    order.last_status = '2'
+    db.session.commit()
+    return jsonify({"status": "success"})
     

--- a/backend-python/logistics/package_api.py
+++ b/backend-python/logistics/package_api.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, send_file
 import datetime
 from app_config import app, db
 from models import *
@@ -9,22 +9,98 @@ from operator import itemgetter
 from sqlalchemy.exc import SQLAlchemyError
 from itertools import groupby
 import os
+import json
 from general_document.purchase_divide_order import generate_excel_file
 from general_document.size_purchase_divide_order import generate_size_excel_file
 from constants import SHOESIZERANGE
 from event_processor import EventProcessor
 from file_locations import FILE_STORAGE_PATH, IMAGE_STORAGE_PATH, IMAGE_UPLOAD_PATH
+from business.batch_info_type import get_order_batch_type_helper
+from general_document.package_purchase_divide_order import generate_package_excel_file
+import zipfile
 
 package_api_bp = Blueprint("package_api", __name__)
 
+
 @package_api_bp.route("/logistics/getnewpackagepurchaseorderid", methods=["GET"])
 def get_new_package_purchase_order_id():
-    """Get a new package purchase order ID."""
     department = "01"
     current_time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")[:-5]
     random_string = randomIdGenerater(6)
     new_id = department + current_time_stamp + random_string + "P"
     return jsonify({"purchaseOrderRid": new_id})
+
+
+@package_api_bp.route("/logistics/getpackagepurchaseorderitems", methods=["GET"])
+def get_package_purchase_order_items():
+    order_id = request.args.get("orderid")
+    purchase_order = (
+        db.session.query(PurchaseOrder)
+        .filter(PurchaseOrder.order_id == order_id,
+                PurchaseOrder.purchase_order_type == "P")
+        .first()
+    )
+    if not purchase_order:
+        return jsonify({"purchaseOrderItems": [], "purchaseOrderId": None, "purchaseOrderRid": None})
+    purchase_order_id = purchase_order.purchase_order_id
+    purchase_order_rid = purchase_order.purchase_order_rid
+    purchase_divide_orders = (
+        db.session.query(PurchaseDivideOrder)
+        .filter(PurchaseDivideOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+    purchase_order_items = []
+    for purchase_divide_order in purchase_divide_orders:
+        purchase_divide_order_id = purchase_divide_order.purchase_divide_order_id
+        purchase_divide_order_size_type = purchase_divide_order.purchase_divide_order_type
+        purchase_divide_order_items = (
+            db.session.query(AssetsPurchaseOrderItem)
+            .filter(
+                AssetsPurchaseOrderItem.purchase_divide_order_id
+                == purchase_divide_order_id
+            )
+            .all()
+        )
+        for item in purchase_divide_order_items:
+            material_info = (
+                db.session.query(Material, MaterialType, MaterialWarehouse)
+                .join(MaterialType, MaterialType.material_type_id == Material.material_type_id)
+                .join(MaterialWarehouse, MaterialWarehouse.material_warehouse_id == MaterialType.warehouse_id)
+                .filter(Material.material_id == item.material_id)
+                .first()
+            )
+            supplier_info = (
+                db.session.query(Supplier)
+                .filter(Supplier.supplier_id == material_info.Material.material_supplier)
+                .first()
+            )
+            purchase_order_items.append(
+                {
+                    "materialName": material_info.Material.material_name,
+                    "materialType": {
+                        "materialTypeId": material_info.Material.material_type_id,
+                        "materialTypeName": material_info.MaterialType.material_type_name,
+                    },
+                    "warehouseName": material_info.MaterialWarehouse.material_warehouse_name,
+                    "unit": material_info.Material.material_unit,
+                    "supplierName": supplier_info.supplier_name,
+                    "purchaseAmount": item.purchase_amount,
+                    "materialSpecification": item.material_specification,
+                    "materialModel": item.material_model,
+                    "materialCategory": 0 if purchase_divide_order_size_type == "N" else 1,
+                    "color": item.color,
+                    "comment": item.remark,
+                    "craftName": item.craft_name,
+                    "sizeInfo": [
+                        {
+                            "size": i,
+                            "purchaseAmount": getattr(item, f"size_{i}_purchase_amount"),
+                        }
+                        for i in SHOESIZERANGE
+                    ],
+                }
+            )
+    return jsonify({"status": "success", "purchaseOrderRid": purchase_order_rid, "purchaseOrderItems": purchase_order_items, "purchaseOrderId": purchase_order_id})
 
 @package_api_bp.route("/logistics/newpackagepurchaseordersave", methods=["POST"])
 def new_package_purchase_order_save():
@@ -168,78 +244,6 @@ def new_package_purchase_order_save():
         print(f"Error: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
     
-@package_api_bp.route("/logistics/getpackagepurchaseorderitems", methods=["GET"])
-def get_package_purchase_order_items():
-    """Get package purchase order items."""
-    order_id = request.args.get("orderid")
-    purchase_order = (
-        db.session.query(PurchaseOrder)
-        .filter(PurchaseOrder.order_id == order_id,
-                PurchaseOrder.purchase_order_type == "P")
-        .first()
-    )
-    if not purchase_order:
-        return jsonify({"status": "error", "message": "Purchase order not found"}), 404
-    purchase_order_id = purchase_order.purchase_order_id
-    purchase_order_rid = purchase_order.purchase_order_rid
-    purchase_divide_orders = (
-        db.session.query(PurchaseDivideOrder)
-        .filter(PurchaseDivideOrder.purchase_order_id == purchase_order_id)
-        .all()
-    )
-    purchase_order_items = []
-    for purchase_divide_order in purchase_divide_orders:
-        purchase_divide_order_id = purchase_divide_order.purchase_divide_order_id
-        purchase_divide_order_size_type = purchase_divide_order.purchase_divide_order_type
-        purchase_divide_order_items = (
-            db.session.query(AssetsPurchaseOrderItem)
-            .filter(
-                AssetsPurchaseOrderItem.purchase_divide_order_id
-                == purchase_divide_order_id
-            )
-            .all()
-        )
-        for item in purchase_divide_order_items:
-            material_info = (
-                db.session.query(Material, MaterialType, MaterialWarehouse)
-                .join(MaterialType, MaterialType.material_type_id == Material.material_type_id)
-                .join(MaterialWarehouse, MaterialWarehouse.material_warehouse_id == MaterialType.warehouse_id)
-                .filter(Material.material_id == item.material_id)
-                .first()
-            )
-            supplier_info = (
-                db.session.query(Supplier)
-                .filter(Supplier.supplier_id == material_info.Material.material_supplier)
-                .first()
-            )
-            purchase_order_items.append(
-                {
-                    "materialName": material_info.Material.material_name,
-                    "materialType": {
-                        "materialTypeId": material_info.Material.material_type_id,
-                        "materialTypeName": material_info.MaterialType.material_type_name,
-                    },
-                    "warehouseName": material_info.MaterialWarehouse.material_warehouse_name,
-                    "unit": material_info.Material.material_unit,
-                    "supplierName": supplier_info.supplier_name,
-                    "purchaseAmount": item.purchase_amount,
-                    "materialSpecification": item.material_specification,
-                    "materialModel": item.material_model,
-                    "materialCategory": 0 if purchase_divide_order_size_type == "N" else 1,
-                    "color": item.color,
-                    "comment": item.remark,
-                    "craftName": item.craft_name,
-                    "sizeInfo": [
-                        {
-                            "size": i,
-                            "purchaseAmount": getattr(item, f"size_{i}_purchase_amount"),
-                        }
-                        for i in SHOESIZERANGE
-                    ],
-                }
-            )
-    return jsonify({"status": "success", "purchaseOrderRid": purchase_order_rid, "purchaseOrderItems": purchase_order_items})
-
 @package_api_bp.route("/logistics/editsavedpackagepurchaseorderitems", methods=["POST"])
 def edit_saved_package_purchase_order_items():
     try:
@@ -402,5 +406,460 @@ def edit_saved_package_purchase_order_items():
         print(f"Error: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
     
+@package_api_bp.route("/logistics/getindividualpurchaseorders", methods=["GET"])
+def get_individual_purchase_orders():
+    purchase_order_id = request.args.get("purchaseOrderId")
 
+    # Fetch the data from the database
+    query = (
+        db.session.query(
+            PurchaseDivideOrder,
+            TotalPurchaseOrder,
+            PurchaseOrder,
+            AssetsPurchaseOrderItem,
+            Material,
+            MaterialType,
+            Supplier,
+        )
+        .outerjoin(
+            TotalPurchaseOrder,
+            PurchaseDivideOrder.total_purchase_order_id
+            == TotalPurchaseOrder.total_purchase_order_id,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+    print(query)
+
+    # Group the results by purchase_divide_order_rid
+    grouped_results = {}
+    for (
+        purchase_divide_order,
+        total_purchase_order,
+        purchase_order,
+        assets_purchase_order_item,
+        material,
+        material_type,
+        supplier,
+    ) in query:
+        divide_order_rid = purchase_divide_order.purchase_divide_order_rid
+        if divide_order_rid not in grouped_results:
+            if total_purchase_order:
+                if total_purchase_order.total_purchase_order_status == "1":
+                    purchase_divide_order_status = "已保存"
+                elif total_purchase_order.total_purchase_order_status == "2":
+                    purchase_divide_order_status = "已下发"
+                else:
+                    purchase_divide_order_status = "未处理"
+            else:
+                purchase_divide_order_status = "未处理"
+            grouped_results[divide_order_rid] = {
+                "purchaseDivideOrderId": divide_order_rid,
+                "purchaseOrderId": purchase_divide_order.purchase_order_id,
+                "supplierName": supplier.supplier_name,
+                "assetsItems": [],
+                "purchaseDivideOrderType": purchase_divide_order.purchase_divide_order_type,
+                "remark": purchase_divide_order.purchase_order_remark,
+                "evironmentalRequest": purchase_divide_order.purchase_order_environmental_request,
+                "shipmentAddress": purchase_divide_order.shipment_address,
+                "shipmentDeadline": purchase_divide_order.shipment_deadline,
+                "purchaseDivideOrderStatus": purchase_divide_order_status,
+            }
+
+        # Append the assets item details to the corresponding group
+        obj = {
+            "materialId": assets_purchase_order_item.material_id,
+            "materialType": material_type.material_type_name,
+            "materialName": material.material_name,
+            "materialModel": assets_purchase_order_item.material_model,
+            "materialSpecification": assets_purchase_order_item.material_specification,
+            "color": assets_purchase_order_item.color,
+            "unit": material.material_unit,
+            "purchaseAmount": assets_purchase_order_item.purchase_amount,
+            "remark": assets_purchase_order_item.remark,
+            "sizeType": assets_purchase_order_item.size_type,
+            
+        }
+        for size in SHOESIZERANGE:
+            obj[f"size{size}Amount"] = getattr(
+                assets_purchase_order_item, f"size_{size}_purchase_amount"
+            )
+        grouped_results[divide_order_rid]["assetsItems"].append(obj)
+
+    # Convert the grouped results to a list
+    result = list(grouped_results.values())
+
+    return jsonify(result)
+
+@package_api_bp.route("/logistics/submitindividualpurchaseorders", methods=["POST"])
+def submit_purchase_divide_orders():
+    purchase_order_id = request.json.get("purchaseOrderId")
+    order_info = (
+        db.session.query(PurchaseOrder, Order)
+        .join(Order, PurchaseOrder.order_id == Order.order_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .first()
+    )
+    order_id = order_info.Order.order_id
+    order_rid = order_info.Order.order_rid
+    materials_data = []
+    query = (
+        db.session.query(
+            PurchaseDivideOrder,
+            PurchaseOrder,
+            AssetsPurchaseOrderItem,
+            Material,
+            MaterialType,
+            Supplier,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+    for (
+        purchase_divide_order,
+        purchase_order,
+        assets_purchase_order_item,
+        material,
+        material_type,
+        supplier,
+    ) in query:
+        current_time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")[:-5]
+        random_string = randomIdGenerater(6)
+        supplier_id_string = str(supplier.supplier_id).zfill(4)
+        total_purchase_order_rid = (
+            "T" + current_time_stamp + random_string + "P" + supplier_id_string
+        )
+        total_purchase_order = TotalPurchaseOrder(
+            total_purchase_order_rid=total_purchase_order_rid,
+            supplier_id=supplier.supplier_id,
+            create_date=datetime.datetime.now(),
+            total_purchase_order_remark="",
+            total_purchase_order_environmental_request="",
+            shipment_address="温州市瓯海区梧田工业基地镇南路8号（健诚集团）",
+            shipment_deadline="请在7-10日内交货",
+            total_purchase_order_status="2",
+        )
+        db.session.add(total_purchase_order)
+        db.session.flush()
+        purchase_divide_order.total_purchase_order_id = total_purchase_order.total_purchase_order_id
+        materials_data.append(
+            {
+                "supplier_name": supplier.supplier_name,
+                "material_name": material.material_name,
+                "model": assets_purchase_order_item.material_model or "",
+                "specification": assets_purchase_order_item.material_specification or "",
+                "purchase_amount": assets_purchase_order_item.purchase_amount,
+            }
+        )
+
+        material_id = assets_purchase_order_item.material_id
+        material_quantity = assets_purchase_order_item.purchase_amount
+        material_specification = assets_purchase_order_item.material_specification
+        material_model = assets_purchase_order_item.material_model
+        color = assets_purchase_order_item.color
+        remark = assets_purchase_order_item.remark
+        size_type = assets_purchase_order_item.size_type
+        craft_name = assets_purchase_order_item.craft_name
+        if purchase_divide_order.purchase_divide_order_type == "N":
+            material_storage = MaterialStorage(
+                order_id = order_id,
+                material_id=material_id,
+                estimated_inbound_amount=material_quantity,
+                actual_inbound_amount=0,
+                current_amount=0,
+                unit_price=0,
+                material_outsource_status="0",
+                material_model=material_model,
+                material_specification=material_specification,
+                material_storage_color=color,
+                total_purchase_order_id=total_purchase_order.total_purchase_order_id,
+                craft_name=craft_name,
+                actual_inbound_material_id=assets_purchase_order_item.inbound_material_id if assets_purchase_order_item.inbound_material_id else assets_purchase_order_item.material_id,
+                actual_inbound_unit=assets_purchase_order_item.inbound_unit if assets_purchase_order_item.inbound_unit else material.material_unit,
+            )
+            db.session.add(material_storage)
+        elif purchase_divide_order.purchase_divide_order_type == "S":
+            quantity_map = {}
+            for size in SHOESIZERANGE:
+                quantity_map[f"size_{size}_quantity"] = getattr(
+                    assets_purchase_order_item, f"size_{size}_purchase_amount"
+                )
+
+            size_material_storage = SizeMaterialStorage(
+                order_id=order_id,
+                material_id=material_id,
+                total_estimated_inbound_amount=material_quantity,
+                unit_price=0,
+                material_outsource_status="0",
+                size_material_model=material_model,
+                size_material_specification=material_specification,
+                size_material_color=color,
+                total_purchase_order_id=total_purchase_order.total_purchase_order_id,
+                craft_name=craft_name,
+            )
+            for size in SHOESIZERANGE:
+                setattr(
+                    size_material_storage,
+                    f"size_{size}_estimated_inbound_amount",
+                    quantity_map[f"size_{size}_quantity"],
+                )
+            db.session.add(size_material_storage)
+    purchase_order_status = "2"
+    db.session.query(PurchaseOrder).filter(
+        PurchaseOrder.purchase_order_id == purchase_order_id
+    ).update({"purchase_order_status": purchase_order_status})
+    db.session.flush()
+    purchase_divide_orders = (
+        db.session.query(
+            PurchaseDivideOrder,
+            AssetsPurchaseOrderItem,
+            PurchaseOrder,
+            Material,
+            Supplier,
+        )
+        .join(
+            AssetsPurchaseOrderItem,
+            PurchaseDivideOrder.purchase_divide_order_id
+            == AssetsPurchaseOrderItem.purchase_divide_order_id,
+        )
+        .join(
+            PurchaseOrder,
+            PurchaseDivideOrder.purchase_order_id == PurchaseOrder.purchase_order_id,
+        )
+        .join(Material, AssetsPurchaseOrderItem.material_id == Material.material_id)
+        .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+        .filter(PurchaseOrder.purchase_order_id == purchase_order_id)
+        .all()
+    )
+
+    # Dictionary to keep track of processed PurchaseDivideOrders
+    purchase_divide_order_dict = {}
+    size_purchase_divide_order_dict = {}
+    if (
+        os.path.exists(
+            os.path.join(FILE_STORAGE_PATH, order_rid)
+        )
+        == False
+    ):
+        os.mkdir(
+            os.path.join(FILE_STORAGE_PATH, order_rid)
+        )
+    customer_name = (
+        db.session.query(Customer)
+        .join(Order, Order.customer_id == Customer.customer_id)
+        .filter(Order.order_id == order_id)
+        .first()
+        .customer_name
+    )
+
+    # Iterate through the query results and group items by PurchaseDivideOrder
+    for (
+        purchase_divide_order,
+        assets_purchase_order_item,
+        purchase_order,
+        material,
+        supplier,
+    ) in purchase_divide_orders:
+        purchase_order_id = purchase_divide_order.purchase_divide_order_rid
+        if purchase_divide_order.purchase_divide_order_type == "N":
+            if purchase_order_id not in purchase_divide_order_dict:
+                purchase_divide_order_dict[purchase_order_id] = {
+                    "供应商": supplier.supplier_name,
+                    "日期": datetime.datetime.now().strftime("%Y-%m-%d"),
+                    "备注": purchase_divide_order.purchase_order_remark,
+                    "环保要求": purchase_divide_order.purchase_order_environmental_request,
+                    "发货地址": purchase_divide_order.shipment_address,
+                    "交货期限": purchase_divide_order.shipment_deadline,
+                    "客户名": customer_name,
+                    "订单信息": order_rid,
+                    "seriesData": [],
+                }
+
+            # Append the current PurchaseOrderItem to the 'seriesData' list of the relevant order
+            purchase_divide_order_dict[purchase_order_id]["seriesData"].append(
+                {
+                    "物品名称": (
+                        material.material_name
+                        + " "
+                        + (assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "")
+                        + " "
+                        + (
+                            assets_purchase_order_item.material_specification
+                            if assets_purchase_order_item.material_specification
+                            else ""
+                        )
+                        + " "
+                        + (assets_purchase_order_item.color if assets_purchase_order_item.color else "")
+                    ),
+                    "型号" : assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "",
+                    "类别" : material.material_name,
+                    "数量": assets_purchase_order_item.purchase_amount,
+                    "单位": material.material_unit,
+                    "备注": assets_purchase_order_item.remark,
+                    "用途说明": "",
+                }
+            )
+        elif purchase_divide_order.purchase_divide_order_type == "S":
+# 获取 order_size_table 并转换为字典
+            order_size_table = (
+                db.session.query(Order)
+                .filter(Order.order_id == order_id)
+                .first()
+                .order_size_table
+            )
+            if order_size_table:
+                order_size_table = json.loads(order_size_table)
+            else:
+                order_size_table = {}  # 确保是字典
+
+            # 获取 batch_info_type 信息
+            batch_info_type = (
+                db.session.query(BatchInfoType, Order)
+                .join(Order, Order.batch_info_type_id == BatchInfoType.batch_info_type_id)
+                .filter(Order.order_id == order_id)
+                .first()
+            )
+
+            # 1️⃣ 创建 "客人码" -> "实际尺码" 映射
+            customer_size_map = {}  # { "7.5": 34, "8.0": 35, "8.5": 36 }
+            for i in SHOESIZERANGE:
+                size_name = getattr(batch_info_type.BatchInfoType, f"size_{i}_name", None)
+                if size_name:
+                    customer_size_map[size_name] = i  # 例如 {"7.5": 34, "8.0": 35, "8.5": 36}
+
+            # 2️⃣ 确保 `order_size_table` 至少有 `客人码`
+            if "客人码" not in order_size_table or not order_size_table["客人码"]:
+                order_size_table["客人码"] = list(customer_size_map.keys())  # 从 batch_info_type 生成客人码
+
+            # 3️⃣ 根据 `material_name` 选择合适的尺码来源
+            if "大底" in material.material_name:
+                size_values = order_size_table.get("大底", order_size_table["客人码"])  # 兜底使用 `客人码`
+            elif "中底" in material.material_name:
+                size_values = order_size_table.get("中底", order_size_table["客人码"])
+            elif "包材" in material.material_name:
+                size_values = order_size_table.get("包材", order_size_table["客人码"])
+            else:
+                size_values = order_size_table["客人码"]
+            print(size_values)
+
+            # 4️⃣ 转换为实际尺码并构造最终的 obj
+            obj = {
+                "物品名称": (
+                    material.material_name
+                    + " "
+                    + (assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "")
+                    + " "
+                    + (
+                        assets_purchase_order_item.material_specification
+                        if assets_purchase_order_item.material_specification
+                        else ""
+                    )
+                    + " "
+                    + (assets_purchase_order_item._color if assets_purchase_order_item.color else "")
+                ),
+                "型号" : assets_purchase_order_item.material_model if assets_purchase_order_item.material_model else "",
+                "类别" : material.material_name,
+                "备注": assets_purchase_order_item.remark,
+            }
+            for index, size_value in enumerate(size_values):
+                customer_value = order_size_table["客人码"][index]
+                if customer_value in customer_size_map:
+                    actual_size = customer_size_map[customer_value]  # 例如 7.5 -> 34
+                    obj[size_value] = getattr(assets_purchase_order_item, f"size_{actual_size}_purchase_amount", 0)
+
+            # 5️⃣ 添加到 seriesData
+            if purchase_order_id not in size_purchase_divide_order_dict:
+                size_purchase_divide_order_dict[purchase_order_id] = {
+                    "供应商": supplier.supplier_name,
+                    "日期": datetime.datetime.now().strftime("%Y-%m-%d"),
+                    "备注": purchase_divide_order.purchase_order_remark,
+                    "客户名": customer_name,
+                    "环保要求": purchase_divide_order.purchase_order_environmental_request,
+                    "发货地址": purchase_divide_order.shipment_address,
+                    "交货期限": purchase_divide_order.shipment_deadline,
+                    "订单信息": order_rid,
+                    "seriesData": [],
+                }
+
+            size_purchase_divide_order_dict[purchase_order_id]["seriesData"].append(obj)
+            print(size_purchase_divide_order_dict)
+    customer_name = (
+        db.session.query(Order, Customer)
+        .join(Customer, Order.customer_id == Customer.customer_id)
+        .filter(Order.order_id == order_id)
+        .first()
+        .Customer.customer_name
+    )
+    generated_files = []
+    # Convert the dictionary to a list
+    template_path = os.path.join(FILE_STORAGE_PATH, "标准采购订单.xlsx")
+    size_template_path = os.path.join(FILE_STORAGE_PATH, "新标准采购订单尺码版.xlsx")
+    for purchase_order_id, data in purchase_divide_order_dict.items():
+        new_file_path = os.path.join(
+            FILE_STORAGE_PATH,
+            order_rid,
+            purchase_order_id + "_包材采购订单_" + data["供应商"] + ".xlsx",
+        )
+        package_info_file_path = os.path.join(
+            FILE_STORAGE_PATH, order_rid, "包装资料.xlsx"
+        )
+        generate_package_excel_file(
+            template_path,
+            new_file_path,
+            package_info_file_path,
+            data,
+        )
+        generated_files.append(new_file_path)
+    shoe_size_names = get_order_batch_type_helper(order_id)
+    zip_file_path = os.path.join(
+        FILE_STORAGE_PATH,
+        order_rid,
+        "包材采购订单.zip",
+    )
+    with zipfile.ZipFile(zip_file_path, "w") as zipf:
+        for file in generated_files:
+            # Extract purchase_order_id from the filename and check if it ends with 'F'
+            filename = os.path.basename(file)
+            purchase_order_id = filename.split("_")[0]  # Get the part before "_供应商"
+            if len(purchase_order_id) >= 5 and purchase_order_id[-5] == "P":
+                zipf.write(file, filename)  # Add the file to the zip
+    order = db.session.query(Order).filter(Order.order_id == order_id).first()
+    order.packaging_status = '2'
+    db.session.commit()
+    return jsonify({"status": "success"})
+
+@package_api_bp.route("/logistics/downloadpackagepurchaseorders", methods=["GET"])
+def download_package_purchase_order():
+    order_id = request.args.get("orderId")
+    order_rid = db.session.query(Order).filter(Order.order_id == order_id).first().order_rid
+    zip_file_path = os.path.join(
+        FILE_STORAGE_PATH,
+        order_rid,
+        "包材采购订单.zip",
+    )
+    return send_file(zip_file_path, as_attachment=True)
     

--- a/backend-python/shared_apis/order.py
+++ b/backend-python/shared_apis/order.py
@@ -250,6 +250,16 @@ def get_order_info():
         "status": (
             entities.OrderStatus.order_current_status if entities.OrderStatus else "N/A"
         ),
+        "lastStatus": (
+            entities.Order.last_status if entities.Order.last_status else "N/A"
+            
+        ),
+        "cuttingModelStatus": (
+            entities.Order.cutting_model_status if entities.Order.cutting_model_status else "N/A"
+        ),
+        "packagingStatus": (
+            entities.Order.packaging_status if entities.Order.packaging_status else "N/A"
+        ),
     }
     return jsonify(result)
 

--- a/backend-python/shared_apis/shoe.py
+++ b/backend-python/shared_apis/shoe.py
@@ -5,6 +5,7 @@ from models import *
 from file_locations import IMAGE_STORAGE_PATH
 from api_utility import to_camel, to_snake
 from login.login import current_user, current_user_info
+import json
 
 shoe_bp = Blueprint("shoe_bp", __name__)
 
@@ -160,4 +161,27 @@ def get_shoe_batch_logistics():
         )
     
     return jsonify(result)
+
+@shoe_bp.route("/shoe/getshoebatchinfotypebysizetable", methods=["GET"])
+def get_shoe_batch_by_size_table():
+    orderId = request.args.get("orderId")
+    if orderId is None:
+        return jsonify("orderId is required"), 400
+    order_size_table = db.session.query(Order).filter_by(order_id = orderId).first().order_size_table
+    #transform order_size_table json to dict
+    order_size_table = json.loads(order_size_table)
+    print(order_size_table)
+    last_order_list = order_size_table['楦头']
+    #trans the list to result like "size34Slot": last_order_list['楦头'][0], max to size47slot, if last_order_list is not enough, fill with None
+    #use index to get the value
+    result = {}
+    for i in range(34, 47):
+        if i - 34 < len(last_order_list):
+            result[f'size{i}Slot'] = last_order_list[i-34]
+        else:
+            result[f'size{i}Slot'] = None
+    print(result)
+    return jsonify(result)
+    
+    
 

--- a/frontend/jiancheng/src/Pages/DevelopmentManager/views/ProductionOrderCreateView.vue
+++ b/frontend/jiancheng/src/Pages/DevelopmentManager/views/ProductionOrderCreateView.vue
@@ -1864,9 +1864,8 @@ export default {
             return Search
         },
         getShoeImageUrl() {
-            // find index of activeTab
-            const index = this.currentOrderShoeRow.typeInfos.findIndex((item) => item.color === this.activeTab)
-            return this.currentOrderShoeRow.typeInfos[index].image
+            const index = this.currentOrderShoeRow.typeInfos.findIndex((item) => item.color === this.activeTab);
+            return index !== -1 ? this.currentOrderShoeRow.typeInfos[index].image : '';
         }
     },
     methods: {
@@ -2251,6 +2250,7 @@ export default {
             this.materialWholeData = []
             this.currentShoeId = row.inheritId
             this.currentShoeImageUrl = row.typeInfos[0].image
+            this.currentOrderShoeRow = row
             await this.getOrderShoeInfo(row.inheritId)
             this.getInstructionData(row)
             this.tabcolor = row.typeInfos.map((info) => info.color)

--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/components/VariousPurchaseTables/PurchaseItemsTable.vue
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/components/VariousPurchaseTables/PurchaseItemsTable.vue
@@ -1,29 +1,13 @@
 <template>
-    <el-select v-model="currentBatchInfoType" @change="changeBatchInfoType" placeholder="请选择鞋型尺码类型" v-if="batchInfoVisible">
-        <el-option
-            v-for="item in batchInfoTypeList"
-            :key="item.batchInfoTypeId"
-            :label="item.batchInfoTypeName"
-            :value="item.batchInfoTypeId"
-        >
-        </el-option>
-    </el-select>
     <el-table :data="localTableData" border height="350">
         <el-table-column label="材料类型">
             <template #default="scope">
                 <el-popover trigger="hover" placement="top">
                     <template #reference>
-                        <el-select
-                            v-model="scope.row.materialType"
-                            @change="changeWarehouseName(scope.row)"
-                            value-key="materialTypeId"
-                        >
-                            <el-option
-                                v-for="item in materialTypeOptions"
-                                :key="item.materialTypeId"
-                                :value="item"
-                                :label="item.materialTypeName"
-                            >
+                        <el-select v-model="scope.row.materialType" @change="changeWarehouseName(scope.row)"
+                            value-key="materialTypeId">
+                            <el-option v-for="item in materialTypeOptions" :key="item.materialTypeId" :value="item"
+                                :label="item.materialTypeName">
                             </el-option>
                         </el-select>
                     </template>
@@ -33,12 +17,8 @@
         <el-table-column prop="warehouseName" label="所属仓库" />
         <el-table-column prop="supplierName" label="厂家名称">
             <template #default="scope">
-                <el-autocomplete
-                    v-model="scope.row.supplierName"
-                    :fetch-suggestions="querySupplierNames"
-                    placeholder="搜索厂家"
-                    @select="handleSupplierNameSelect(scope.row, $event)"
-                >
+                <el-autocomplete v-model="scope.row.supplierName" :fetch-suggestions="querySupplierNames"
+                    placeholder="搜索厂家" @select="handleSupplierNameSelect(scope.row, $event)">
                 </el-autocomplete>
             </template>
         </el-table-column>
@@ -60,22 +40,12 @@
         </el-table-column>
         <el-table-column label="材料规格">
             <template #default="scope">
-                <el-input
-                    v-model="scope.row.materialSpecification"
-                    placeholder=""
-                    type="textarea"
-                    clearable
-                ></el-input>
+                <el-input v-model="scope.row.materialSpecification" placeholder="" type="textarea" clearable></el-input>
             </template>
         </el-table-column>
         <el-table-column label="工艺名称">
             <template #default="scope">
-                <el-input
-                    v-model="scope.row.craftName"
-                    placeholder=""
-                    type="textarea"
-                    clearable
-                ></el-input>
+                <el-input v-model="scope.row.craftName" placeholder="" type="textarea" clearable></el-input>
             </template>
         </el-table-column>
         <el-table-column label="颜色">
@@ -86,97 +56,52 @@
         <el-table-column prop="unit" label="单位">
         </el-table-column>
         <el-table-column prop="purchaseAmount" label="采购数量">
-            
+
             <template #default="scope">
-                
-                <el-input-number
-                    v-if="scope.row.materialCategory == 0"
-                    v-model="scope.row.purchaseAmount"
-                    :min="0"
-                    :step="0.0001"
-                    size="small"
-                />
+
+                <el-input-number v-if="scope.row.materialCategory == 0" v-model="scope.row.purchaseAmount" :min="0"
+                    :step="0.0001" size="small" />
                 <div v-if="scope.row.materialCategory == 1">
                     {{ scope.row.purchaseAmount }}
-                    <el-button
-                    
-                    type="primary"
-                    size="default"
-                    @click="openSizeDialog(scope.row, scope.$index)"
-                    >尺码用量填写</el-button
-                >
+                    <el-button type="primary" size="default"
+                        @click="openSizeDialog(scope.row, scope.$index)">尺码用量填写</el-button>
                 </div>
 
             </template>
         </el-table-column>
         <el-table-column label="备注">
             <template #default="scope">
-                <el-input
-                    v-model="scope.row.comment"
-                    placeholder=""
-                    size="default"
-                    clearable
-                    type="textarea"
-                ></el-input>
+                <el-input v-model="scope.row.comment" placeholder="" size="default" clearable
+                    type="textarea"></el-input>
             </template>
         </el-table-column>
         <el-table-column label="操作">
             <template #default="scope">
-                <el-button size="small" type="danger" @click="deleteCurrentRow(scope.$index)"
-                    >删除</el-button
-                >
+                <el-button size="small" type="danger" @click="deleteCurrentRow(scope.$index)">删除</el-button>
             </template>
         </el-table-column>
     </el-table>
     <el-button type="primary" @click="openNewMaterialDialog">添加新材料</el-button>
     <el-button type="primary" @click="manualAddMaterial">手动添加材料</el-button>
 
-    <el-dialog
-        title="添加新采购材料"
-        v-model="newMaterialVis"
-        width="60%"
-        :close-on-click-modal="false"
-    >
+    <el-dialog title="添加新采购材料" v-model="newMaterialVis" width="60%" :close-on-click-modal="false">
         <el-row :gutter="20">
             <el-col :span="6" :offset="0">
-                <el-input
-                    v-model="addMaterialDialogField.materialTypeSearch"
-                    placeholder="输入材料类型"
-                    size="default"
-                    :suffix-icon="Search"
-                    clearable
-                    @change="getMaterialFilterData(currentCreateViewId)"
-                ></el-input>
+                <el-input v-model="addMaterialDialogField.materialTypeSearch" placeholder="输入材料类型" size="default"
+                    :suffix-icon="Search" clearable @change="getMaterialFilterData(currentCreateViewId)"></el-input>
             </el-col>
             <el-col :span="6" :offset="0">
-                <el-input
-                    v-model="addMaterialDialogField.materialSearch"
-                    placeholder="输入材料名称"
-                    size="default"
-                    :suffix-icon="Search"
-                    clearable
-                    @change="getMaterialFilterData(currentCreateViewId)"
-                ></el-input>
+                <el-input v-model="addMaterialDialogField.materialSearch" placeholder="输入材料名称" size="default"
+                    :suffix-icon="Search" clearable @change="getMaterialFilterData(currentCreateViewId)"></el-input>
             </el-col>
             <el-col :span="6" :offset="0">
-                <el-input
-                    v-model="addMaterialDialogField.factorySearch"
-                    placeholder="输入厂家名称"
-                    size="default"
-                    :suffix-icon="Search"
-                    clearable
-                    @change="getMaterialFilterData(currentCreateViewId)"
-                ></el-input>
+                <el-input v-model="addMaterialDialogField.factorySearch" placeholder="输入厂家名称" size="default"
+                    :suffix-icon="Search" clearable @change="getMaterialFilterData(currentCreateViewId)"></el-input>
             </el-col>
         </el-row>
         <el-row :gutter="20">
-            <el-table
-                :data="assetFilterTable"
-                border
-                ref="materialSelectTable"
-                @selection-change="handleMaterialSelectionChange"
-                style="height: 400px"
-            >
+            <el-table :data="assetFilterTable" border ref="materialSelectTable"
+                @selection-change="handleMaterialSelectionChange" style="height: 400px">
                 <el-table-column type="selection" width="55"></el-table-column>
                 <el-table-column prop="materialType" label="材料类型" />
                 <el-table-column prop="materialName" label="材料名称" />
@@ -192,12 +117,7 @@
             </span>
         </template>
     </el-dialog>
-    <el-dialog
-        title="尺码数量填写"
-        v-model="isSizeDialogVisible"
-        width="60%"
-        :close-on-click-modal="false"
-    >
+    <el-dialog title="尺码数量填写" v-model="isSizeDialogVisible" width="60%" :close-on-click-modal="false">
         <span>{{ `尺码名称: ${currentShoeSizeType}` }}</span>
         <el-table :data="sizeData" border stripe>
             <el-table-column prop="size" label="尺码"></el-table-column>
@@ -221,7 +141,7 @@ import { markRaw } from 'vue'
 import { Search } from '@element-plus/icons-vue'
 import { ElMessageBox } from 'element-plus'
 export default {
-    props: ['materialTypeOptions', 'purchaseData', 'batchInfoVisible', 'typeLimit'],
+    props: ['materialTypeOptions', 'purchaseData', 'typeLimit', 'orderId'],
     data() {
         return {
             Search: markRaw(Search),
@@ -230,7 +150,9 @@ export default {
             isChooseOrderShoeDialogOpen: false,
             currentMaterialRow: {},
             selectedOrderId: null,
-            localTableData: [],
+            localTableData: [
+                ...this.purchaseData
+            ],
             newItemTemplate: {
                 materialName: null,
                 materialType: null,
@@ -264,14 +186,20 @@ export default {
         }
     },
     watch: {
-        purchaseData(newItems) {
-            this.localTableData = [...newItems]
+        localTableData: {
+            handler(newValue) {
+                console.log("🟡 Emitting update from child:", newValue);
+                this.$emit('update-items', [...newValue]); // Emit to parent
+            },
+            deep: true, // Ensure deep watching for arrays
+            immediate: true
         }
     },
-    emits: ['update-items', 'update-current-batch-info-type'],
+    emits: ['update-items'],
     mounted() {
         this.getBatchTypeList()
         this.getAllMaterialName()
+        console.log(this.localTableData)
     },
     methods: {
         async getAllMaterialName() {
@@ -283,6 +211,7 @@ export default {
             this.materialNameOptions = response.data
         },
         emitUpdate() {
+            console.log("🟠 Emitting update: ", this.localTableData);
             this.$emit('update-items', [...this.localTableData])
         },
         changeBatchInfoType() {
@@ -290,13 +219,6 @@ export default {
             this.newItemTemplate.sizeInfo = []
 
             // Find the selected batch info type
-            const selectedBatchInfoType = this.batchInfoTypeList.find(
-                (item) => item.batchInfoTypeId === this.currentBatchInfoType
-            )
-
-            // Update the current shoe size type
-            this.currentShoeSizeType = selectedBatchInfoType.batchInfoTypeName
-            this.$emit('update-current-batch-info-type', this.currentShoeSizeType);
 
             // Map the size slots into the desired format
             const sizeSlots = [
@@ -312,22 +234,28 @@ export default {
                 { size: '43', slotName: 'size43Slot' },
                 { size: '44', slotName: 'size44Slot' },
                 { size: '45', slotName: 'size45Slot' },
-                { size: '46', slotName: 'size46Slot' }
+                { size: '46', slotName: 'size46Slot' },
+                { size: '47', slotName: 'size47Slot' },
             ]
 
             this.newItemTemplate.sizeInfo = sizeSlots
-                .filter((slot) => selectedBatchInfoType[slot.slotName]) // Only include defined slots
+                .filter((slot) => this.batchInfoTypeList[slot.slotName]) // Only include defined slots
                 .map((slot) => ({
-                    size: selectedBatchInfoType[slot.slotName], // Get the size name from the slot
+                    size: this.batchInfoTypeList[slot.slotName], // Get the size name from the slot
                     purchaseAmount: 0 // Initialize purchase amount
                 }))
 
             console.log(this.newItemTemplate.sizeInfo)
         },
         async getBatchTypeList() {
-            const response = await axios.get(`${this.$apiBaseUrl}/shoe/getshoebatchinfotypelogistics`, {})
+            const response = await axios.get(`${this.$apiBaseUrl}/shoe/getshoebatchinfotypebysizetable`, {
+                params: {
+                    orderId: this.orderId
+                }
+            })
             console.log(response.data)
             this.batchInfoTypeList = response.data
+            this.changeBatchInfoType()
         },
         async querySupplierNames(queryString, callback) {
             if (queryString.trim()) {

--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/routers/logistics.js
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/routers/logistics.js
@@ -47,7 +47,7 @@ export default [
     }
   },
   {
-    path: '/packagepurchase',
+    path: '/packagepurchase/orderid=:orderid',
     name: 'packagepurchase',
     component: PackagePurchaseView,
     props: true,
@@ -58,7 +58,7 @@ export default [
 
   },
   {
-    path: '/lastpurchase',
+    path: '/lastpurchase/orderid=:orderid',
     name: 'lastpurchase',
     component: LastPurchaseView,
     props: true,
@@ -68,7 +68,7 @@ export default [
     }
   },
   {
-    path: '/cutmodelpurchase',
+    path: '/cutmodelpurchase/orderid=:orderid',
     name: 'cutmodelpurchase',
     component: CutModelPurchaseView,
     props: true,

--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/LogisticsControlManager.vue
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/LogisticsControlManager.vue
@@ -19,12 +19,12 @@
                         <el-menu-item index="2" @click="handleMenuClick(2)">
                             <span>一次采购订单创建</span>
                         </el-menu-item>
-                        <el-menu-item index="3" @click="handleMenuClick(3)">
+                        <!-- <el-menu-item index="3" @click="handleMenuClick(3)">
                             <span>批量采购订单生成及下发</span>
                         </el-menu-item>
                         <el-menu-item index="4" @click="handleMenuClick(4)">
                             <span>耗材/固定资产订单生成</span>
-                        </el-menu-item>
+                        </el-menu-item> -->
                         <el-menu-item index="5" @click="handleMenuClick(5)">
                             <span>材料管理</span>
                         </el-menu-item>
@@ -113,12 +113,6 @@ export default {
                     break
                 case 2:
                     this.currentComponent = 'FirstPurchase'
-                    break
-                case 3:
-                    this.currentComponent = 'MultiPurchaseIssue'
-                    break
-                case 4:
-                    this.currentComponent = 'FixedAssets'
                     break
                 case 5:
                     this.currentComponent = 'MaterialManagement'

--- a/frontend/jiancheng/src/components/CutModelPurchaseView.vue
+++ b/frontend/jiancheng/src/components/CutModelPurchaseView.vue
@@ -3,109 +3,60 @@
         <el-main style="height: 100vh;">
             <el-row :gutter="20" style="text-align: center;">
                 <el-col :span="24" :offset="0" style="font-size: xx-large; text-align: center;">
-                    {{ `刀模采购` }}
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="1" :offset="0">
-                    <el-text style="white-space: nowrap;">订单筛选：</el-text>
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-input v-model="orderSearch" placeholder="请输入订单号" clearable @input="handleFilter"></el-input>        
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-input v-model="customerSearch" placeholder="请输入客户名" clearable @input="handleFilter"></el-input>
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-radio-group v-model="orderCuttingModelStatus" size="medium" @change="handleFilter">
-                        <el-radio-button label="0">未采购</el-radio-button>
-                        <el-radio-button label="1">已保存</el-radio-button>
-                        <el-radio-button label="2">已采购</el-radio-button>
-                    </el-radio-group>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-table :data="paginatedList" border stripe height="250" style="width: 100%">
-                        <el-table-column prop="orderRid" label="订单号"></el-table-column>
-                        <el-table-column prop="orderCid" label="客户订单号"></el-table-column>
-                        <el-table-column prop="customerName" label="客户名"></el-table-column>
-                        <el-table-column prop="orderStartDate" label="下单日期"></el-table-column>
-                        <el-table-column prop="orderStatus" label="订单状态"></el-table-column>
-                        <el-table-column prop="orderCuttingModelStatus" label="刀模采购状态" :formatter="cutmodelStatusFormatter"></el-table-column>
-                        <el-table-column label="操作" width="400">
-                            <template #default="scope">
-                                <div v-if="scope.row.orderCuttingModelStatus === '0'">
-                                    <el-button type="primary" size="mini" @click="openSizeComparisonDialog(scope.row)">查看开发部尺码对照表</el-button>
-                                    <el-button type="primary" size="mini" @click="createcutModelPurchaseOrder(scope.row)">创建刀模采购订单</el-button>
-                                </div>
-                                <div v-else-if="scope.row.orderCuttingModelStatus === '1'">
-                                    <el-button type="primary" size="mini" @click="openSizeComparisonDialog(scope.row)">查看开发部尺码对照表</el-button>
-                                    <el-button type="primary" size="mini" @click="editcutModelPurchaseOrder(scope.row)">编辑刀模采购订单</el-button>
-                                </div>
-                                <div v-else>
-                                    <el-button type="primary" size="mini" @click="openSizeComparisonDialog(scope.row)">查看开发部尺码对照表</el-button>
-                                </div>
-                            </template>
-                        </el-table-column>
-                    </el-table>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-pagination
-                        @size-change="handleSizeChange"
-                        @current-change="handleCurrentChange"
-                        :current-page="currentPage"
-                        :page-sizes="[10, 20, 30, 40]"
-                        :page-size="pageSize"
-                        layout="total, sizes, prev, pager, next, jumper"
-                        :total="filteredList.length">
-                    </el-pagination>
+                    {{ `刀模采购 ${currentOrderRid} ${currentEditPurchaseOrderRid}` }}
                 </el-col>
             </el-row>
             <el-divider></el-divider>
             <el-row :gutter="20">
                 <el-col :span="8" :offset="0" :key="currentEditPurchaseOrderRid">
-                    采购订单创建 {{ currentEditPurchaseOrderRid }}
+                    刀模信息
                 </el-col>
             </el-row>
             <el-row :gutter="20">
                 <el-col :span="12" :offset="6">
-                    <el-descriptions border>
+                    <el-descriptions border column="3">
+                        <el-descriptions-item label="刀模类型">{{ currentCutModelType }}</el-descriptions-item>
                         <el-descriptions-item label="刀模库存信息">
-                            <el-button type="primary" size="default" @click="opencutModelSearchDialog" :disabled="currentEditPurchaseOrderRid===''">刀模查询</el-button>
-                            
+                            <el-button type="primary" size="default" @click="openCutModelSearchDialog"
+                                :disabled="currentEditPurchaseOrderRid === ''">刀模查询</el-button>
+                        </el-descriptions-item>
+                        <el-descriptions-item label="订单尺码对照表">
+                            <el-button type="primary" size="default" @click="openSizeComparisonDialog"
+                                :disabled="currentEditPurchaseOrderRid === ''">查看</el-button>
                         </el-descriptions-item>
                     </el-descriptions>
                 </el-col>
             </el-row>
-            <div v-if="currentEditPurchaseOrderRid !== ''">
             <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-form ref="purchaseForm" :model="assetForm" :rules="rules">
-                        <purchase-items-table 
-                            :material-type-options="materialTypeOptions" 
-                            @update-items="updateNewPurchaseData"
-                            :batch-info-visible="1"
-                            :purchaseData.sync="assetForm.purchaseData"
-                            :type-limit="[11]"
-                        ></purchase-items-table>
-                    </el-form>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="4" :offset="22">
-                    <el-button type="primary" size="medium" @click="savecutModelPurchaseOrder" :disabled="currentEditPurchaseOrderRid === ''">保存采购订单</el-button>
+                <el-col :span="12" :offset="0">
+                    <el-button type="primary" size="default" @click="createCutModelPurchaseOrder(orderid)">加载订单</el-button>
 
                 </el-col>
             </el-row>
-        </div>
+
+            <div v-if="currentEditPurchaseOrderRid !== ''">
+                <el-row :gutter="20">
+                    <el-col :span="24" :offset="0">
+                        <el-form ref="purchaseForm" :model="assetForm" :rules="rules">
+                            <purchase-items-table :material-type-options="materialTypeOptions"
+                                @update-items="updateNewPurchaseData" :purchase-data="assetForm.purchaseData"
+                                :type-limit="[12]" :order-id="orderid"></purchase-items-table>
+                        </el-form>
+                    </el-col>
+                </el-row>
+                <el-row :gutter="20">
+                    <el-col :span="8" :offset="18">
+                        <el-button type="primary" size="medium" @click="saveCutModelPurchaseOrder"
+                            :disabled="currentEditPurchaseOrderRid === ''">保存采购订单</el-button>
+                        <el-button type="warning" size="medium" @click="openSubmitDialog"
+                            :disabled="currentEditPurchaseOrderRid === ''">提交采购订单</el-button>
+                        <el-button type="danger" size="default" @click="jumpOverCutModelPurchase">利用库存，无需采购</el-button>
+
+                    </el-col>
+                </el-row>
+            </div>
         </el-main>
-        <el-dialog
-            :title="`订单 ${currentOrderRid} 开发部尺码对照表`"
-            v-model="isSizeComparisonDialogVisible"
-            width="80%"
+        <el-dialog :title="`订单 ${currentOrderRid} 开发部尺码对照表`" v-model="isSizeComparisonDialogVisible" width="80%"
             draggable="true">
             <span>
                 <el-row justify="center" align="middle">
@@ -120,40 +71,112 @@
                 </el-row>
             </span>
             <template #footer>
-            <span>
-                <el-button @click="isSizeComparisonDialogVisible = false">Cancel</el-button>
-                <el-button type="primary" @click="">OK</el-button>
-            </span>
+                <span>
+                    <el-button @click="isSizeComparisonDialogVisible = false">Cancel</el-button>
+                    <el-button type="primary" @click="">OK</el-button>
+                </span>
             </template>
         </el-dialog>
-        <el-dialog
-            title="刀模库存信息查询"
-            v-model="iscutModelSearchDialogVisable"
-            width="80%">
+        <el-dialog title="刀模库存信息查询" v-model="isCutModelSearchDialogVisable" width="80%">
             <span>
-                <el-input v-model="cutmodelNameSearch" placeholder="请输入刀模型号" clearable @change="searchCutModel"></el-input>
+                <el-input v-model="cutModelNameSearch" placeholder="请输入刀模型号" clearable @change="searchCutModel"></el-input>
                 <el-table :data="filteredMaterialList" border stripe style="width: 100%">
                     <el-table-column prop="materialName" label="材料名称"></el-table-column>
                     <el-table-column prop="materialModel" label="材料型号"></el-table-column>
                     <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
                     <el-table-column prop="purchaseAmount" label="采购数量" />
-                                    <el-table-column :label="`分码数量 (${currentShoeSizeType})`">
-                                        <el-table-column v-for="column in filteredColumns(
-                                            filteredMaterialList
-                                        )" :key="column.prop" :prop="column.prop"
-                                            :label="column.label"></el-table-column>
-                                    </el-table-column>
+                    <el-table-column :label="`分码数量 (${currentShoeSizeType})`">
+                        <el-table-column v-for="column in filteredColumns(
+                            filteredMaterialList
+                        )" :key="column.prop" :prop="column.prop" :label="column.label"></el-table-column>
+                    </el-table-column>
                 </el-table>
             </span>
             <template #footer>
-            <span>
-                <el-button @click="iscutModelSearchDialogVisable = false">Cancel</el-button>
-                <el-button type="primary" @click="">OK</el-button>
-            </span>
+                <span>
+                    <el-button @click="isCutModelSearchDialogVisable = false">Cancel</el-button>
+                    <el-button type="primary" @click="">OK</el-button>
+                </span>
             </template>
         </el-dialog>
-        
-        
+        <el-dialog title="采购订单创建页面" v-model="purchaseOrderCreateVis" width="80%" :close-on-click-modal="false">
+            <span v-if="activeTab === ''"> 无需购买材料，推进流程即可。 </span>
+            <el-tabs v-if="activeTab !== ''" v-model="activeTab" type="card" tab-position="top">
+                <el-tab-pane v-for="(item, index) in tabPlaneData" :key="index"
+                    :label="item.purchaseDivideOrderId + '    ' + item.supplierName" :name="item.purchaseDivideOrderId"
+                    style="min-height: 500px">
+                    <el-row :gutter="20">
+                        <el-col :span="12" :offset="0"><span>订单备注：
+                                <el-input v-model="item.remark" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input> </span></el-col>
+                        <el-col :span="12" :offset="0">
+                            <span>环境要求：
+                                <el-input v-model="item.evironmentalRequest" placeholder="" type="textarea"
+                                    resize="none" clearable></el-input>
+                            </span>
+                        </el-col>
+                    </el-row>
+                    <el-row :gutter="20">
+                        <el-col :span="12" :offset="0">
+                            <span>发货地址：
+                                <el-input v-model="item.shipmentAddress" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input>
+                            </span>
+                        </el-col>
+                        <el-col :span="12" :offset="0">
+                            <span>交货周期：
+                                <el-input v-model="item.shipmentDeadline" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input>
+                            </span>
+                        </el-col>
+                    </el-row>
+                    <el-row :gutter="20" style="margin-top: 20px">
+                        <el-col :span="24" :offset="0">
+                            <div v-if="factoryFieldJudge(item.purchaseDivideOrderType)">
+                                <el-table :data="item.assetsItems" border style="width: 100%" height="500">
+                                    <el-table-column type="index" label="编号" />
+                                    <el-table-column prop="materialType" label="材料类型"></el-table-column>
+                                    <el-table-column prop="materialName" label="材料名称" />
+                                    <el-table-column prop="materialModel" label="材料型号" />
+                                    <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
+                                    <el-table-column prop="unit" label="单位" />
+
+                                    <el-table-column prop="purchaseAmount" label="采购数量" />
+                                    <el-table-column :label="`分码数量`">
+                                        <el-table-column v-for="column in filteredColumns(item.assetsItems)"
+                                            :key="column.prop" :prop="column.prop"
+                                            :label="column.label"></el-table-column>
+                                    </el-table-column>
+                                </el-table>
+                            </div>
+                            <div v-else>
+                                <el-table :data="item.assetsItems" border stripe height="500">
+                                    <el-table-column type="index"></el-table-column>
+                                    <el-table-column prop="materialType" label="材料类型"></el-table-column>
+                                    <el-table-column prop="materialName" label="材料名称" />
+                                    <el-table-column prop="materialModel" label="材料型号" />
+                                    <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
+                                    <el-table-column prop="color" label="颜色" />
+                                    <el-table-column prop="unit" label="单位" />
+                                    <el-table-column prop="purchaseAmount" label="数量" />
+                                    <el-table-column prop="remark" label="开发部备注" />
+                                </el-table>
+                            </div>
+                        </el-col>
+                    </el-row>
+                </el-tab-pane>
+            </el-tabs>
+
+            <template #footer>
+                <span>
+                    <el-button @click="purchaseOrderCreateVis = false">取消</el-button>
+                    <el-button type="primary" @click="confirmPurchaseDivideOrderSave">保存</el-button>
+                    <el-button type="success" @click="confirmPurchaseDivideOrderSubmit">提交</el-button>
+                </span>
+            </template>
+        </el-dialog>
+
+
     </el-container>
 </template>
 
@@ -163,30 +186,35 @@ import PurchaseItemsTable from '@/Pages/LogisticsControlDepartment/LogisticsCont
 import { ElMessage } from 'element-plus';
 import { getShoeSizesName } from '@/Pages/utils/getShoeSizesName'
 export default {
+    props: ['orderid'],
     components: {
         PurchaseItemsTable
     },
     data() {
         return {
             getShoeSizesName,
-            iscutModelSearchDialogVisable: false,
+            purchaseOrderCreateVis: false,
+            activeTab: '',
+            tabPlaneData: [],
+            isCutModelSearchDialogVisable: false,
             isSizeComparisonDialogVisible: false,
             orderSearch: '',
             customerSearch: '',
             currentOrderRid: '',
-            cutmodelNameSearch: '',
+            cutModelNameSearch: '',
             filteredMaterialList: [],
             orderList: [],
             filteredList: [],
             currentPage: 1,
             pageSize: 10,
-            currentcutModelType: '',
-            orderCuttingModelStatus: '0',
+            currentCutModelType: '',
+            orderCutModelStatus: '0',
             materialTypeOptions: [],
             currentEditPurchaseOrderRid: '',
             currentEditPurchaseOrderId: 0,
             createEditSymbol: 0,
             currentShoeSizeType: '',
+            currentOrderDBId: 0,
             sizeGridOptions: [],
             shoeSizeColumns: [],
             sizeLabelColumns: [],
@@ -220,7 +248,9 @@ export default {
                                 callback(new Error("尚未选择订单鞋型"));
                             } else {
                                 callback();
+
                             }
+
                         },
                         trigger: "change",
                     },
@@ -235,10 +265,64 @@ export default {
         }
     },
     mounted() {
-        this.getAllOrders();
+        this.getOrderInfo(this.orderid);
         this.getAllMaterialTypes();
+        this.getCurrentPurchaseOrder();
+        this.getBatchTypeList();
+
     },
     methods: {
+        async getCurrentPurchaseOrder() {
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/getcutModelpurchaseorderitems`, {
+                params: {
+                    orderid: this.orderid
+                }
+            });
+            this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
+            this.currentEditPurchaseOrderId = response.data.purchaseOrderId;
+            this.assetForm.purchaseData = response.data.purchaseOrderItems;
+            this.assetForm.orderId = this.orderid;
+            this.assetForm.purchaseOrderType = 'L';
+            const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getcutModelinfo`, {
+                params: {
+                    orderid: this.orderid
+                }
+            });
+            this.currentCutModelType = response2.data.cutModelType;
+            if (this.currentEditPurchaseOrderId === null) {
+                {
+                    this.createCutModelPurchaseOrder(this.orderid)
+                }
+            }
+            else {
+                this.createEditSymbol = 1
+            }
+        },
+        async openSubmitDialog() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/logistics/getindividualpurchaseorders`,
+                {
+                    params: {
+                        purchaseOrderId: this.currentEditPurchaseOrderId
+                    }
+                }
+            )
+            this.tabPlaneData = response.data
+            console.log(this.tabPlaneData)
+            if (this.tabPlaneData.length > 0) {
+                this.activeTab = this.tabPlaneData[0].purchaseDivideOrderId
+            }
+            this.purchaseOrderCreateVis = true
+        },
+        async getOrderInfo(orderId) {
+            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo`, {
+                params: {
+                    orderid: orderId
+                }
+            });
+            this.currentOrderRid = response.data.orderId;
+            this.currentOrderDBId = response.data.orderDBId;
+        },
         async getAllOrders() {
             try {
                 const response = await axios.get(`${this.$apiBaseUrl}/order/getallorders`);
@@ -254,57 +338,64 @@ export default {
             this.materialTypeOptions = response.data.filter(materialType => materialType.materialTypeName === '刀模');
         },
         async searchCutModel() {
-            const response = await axios.get(`${this.$apiBaseUrl}/logistics/searchcutmodelmaterialinfo`, {
+            this.filteredMaterialList = [];
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/searchcutModelmaterialinfo`, {
                 params: {
-                    materialModel: this.cutmodelNameSearch
+                    materialModel: this.cutModelNameSearch
                 }
             });
             this.filteredMaterialList = response.data.data;
         },
-        async opencutModelSearchDialog() {
+        async openCutModelSearchDialog() {
             this.shoeSizeColumns = await this.getShoeSizesName(this.assetForm.orderId)
             this.currentShoeSizeType = this.shoeSizeColumns[0].type
-            this.iscutModelSearchDialogVisable = true;
-            this.cutmodelNameSearch = this.currentcutModelType;
-            this.cutmodelNameSearch = this.cutmodelNameSearch.replace(/[^a-zA-Z0-9]/g, '');
+            this.isCutModelSearchDialogVisable = true;
+            this.cutModelNameSearch = this.currentCutModelType;
+            this.cutModelNameSearch = this.cutModelNameSearch.replace(/[^a-zA-Z0-9]/g, '');
             this.filteredMaterialList = [];
-            const response = await axios.get(`${this.$apiBaseUrl}/logistics/searchcutmodelmaterialinfo`, {
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/searchcutModelmaterialinfo`, {
                 params: {
-                    materialModel: this.cutmodelNameSearch
+                    materialModel: this.cutModelNameSearch
                 }
             });
             this.filteredMaterialList = response.data.data;
-            
+
         },
-        async openSizeComparisonDialog(row) {
-            this.currentOrderRid = row.orderRid;
-            await this.getSizeTableData(row);
+        async openSizeComparisonDialog() {
+            await this.getSizeTableData();
             this.sizeGridOptions.editConfig = false;
             for (let item of this.sizeGridOptions.columns) {
                 item.width = 125;
             }
             this.isSizeComparisonDialogVisible = true;
         },
-        async getSizeTableData(row) {
+        async getSizeTableData() {
             const response = await axios.get(
-                `${this.$apiBaseUrl}/devproductionorder/getsizetable?orderId=${row.orderDbId}`
+                `${this.$apiBaseUrl}/devproductionorder/getsizetable?orderId=${this.currentOrderDBId}`
             )
 
             this.sizeGridOptions = response.data
             console.log(this.sizeGridOptions)
         },
         filteredColumns(array) {
-            return this.shoeSizeColumns.filter((column) =>
-                array.some(
-                    (row) =>
-                        row[column.prop] !== undefined &&
-                        row[column.prop] !== null &&
-                        row[column.prop] !== 0
-                )
-            )
+            if (!array || !this.sizeLabelColumns) return [];
+
+            return Object.keys(this.sizeLabelColumns)
+                .map((slotKey) => {
+                    const amountKey = slotKey.replace("Slot", "Amount"); // Convert size34Slot → size34Amount
+
+                    if (array.some(row => row[amountKey] !== undefined && row[amountKey] !== 0)) {
+                        return {
+                            prop: amountKey,
+                            label: this.sizeLabelColumns[slotKey] // Use size number (e.g., "34", "35")
+                        };
+                    }
+                    return null;
+                })
+                .filter(column => column !== null); // Remove null values
         },
-        cutmodelStatusFormatter(row) {
-            switch (row.orderCuttingModelStatus) {
+        cutModelStatusFormatter(row) {
+            switch (row.orderCutModelStatus) {
                 case '0':
                     return '未采购';
                 case '1':
@@ -313,87 +404,55 @@ export default {
                     return '已采购';
             }
         },
-        async createcutModelPurchaseOrder(row) {
-            if (this.currentEditPurchaseOrderRid != '') {
-                this.$confirm('当前有未保存的采购订单，是否放弃编辑?', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(async () => {
-                    this.currentEditPurchaseOrderRid = '';
-                    const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewcutmodelpurchaseorderid`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                    this.createEditSymbol = 0;
-                    this.assetForm.purchaseData = [];
-                    this.assetForm.orderId = row.orderDbId;
-                    this.assetForm.purchaseOrderType = 'C';
-                    console.log(this.currentEditPurchaseOrderRid);
-                    return
-                }).catch(() => {
-                    return;
+        async createCutModelPurchaseOrder(orderid) {
+            console.log(this.currentEditPurchaseOrderRid);
+            if (this.currentEditPurchaseOrderRid !== '') {
+                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getcutModelpurchaseorderitems`, {
+                    params: {
+                        orderid: orderid
+                    }
                 });
+                this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
+                this.currentEditPurchaseOrderId = response.data.purchaseOrderId;
+                console.log(response.data.purchaseOrderItems)
+                this.assetForm.purchaseData = response.data.purchaseOrderItems;
+                this.assetForm.orderId = orderid;
+                this.assetForm.purchaseOrderType = 'L';
+                console.log(this.assetForm)
+                console.log(this.currentEditPurchaseOrderRid);
+                const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getcutModelinfo`, {
+                    params: {
+                        orderid: orderid
+                    }
+                });
+                this.currentCutModelType = response2.data.cutModelType;
+                this.createEditSymbol = 1
             }
             else {
-                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewcutmodelpurchaseorderid`, {
+                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewcutModelpurchaseorderid`, {
                     params: {
-                        orderid: row.orderDbId
+                        orderid: orderid
                     }
                 });
                 this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
                 this.createEditSymbol = 0;
                 this.assetForm.purchaseData = [];
-                this.assetForm.orderId = row.orderDbId;
-                this.assetForm.purchaseOrderType = 'C';
+                this.assetForm.orderId = orderid;
+                this.assetForm.purchaseOrderType = 'L';
                 console.log(this.currentEditPurchaseOrderRid);
-            }
-        },
-        async editcutModelPurchaseOrder(row) {
-            if (this.currentEditPurchaseOrderRid != '') {
-                this.$confirm('当前有未保存的采购订单，是否放弃编辑?', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(async () => {
-                    this.currentEditPurchaseOrderRid = '';
-                    const response = await axios.get(`${this.$apiBaseUrl}/logistics/getcutmodelpurchaseorderitems`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                    this.createEditSymbol = 1;
-                    this.assetForm.purchaseData = response.data.purchaseOrderItems;
-                    this.assetForm.orderId = row.orderDbId;
-                    this.assetForm.purchaseOrderType = 'C';
-                    console.log(this.currentEditPurchaseOrderRid);
-                    return
-                }).catch(() => {
-                    return;
-                });
-            }
-            else {
-                this.createEditSymbol = 1;
-                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getcutmodelpurchaseorderitems`, {
+                const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getcutModelinfo`, {
                     params: {
-                        orderid: row.orderDbId
+                        orderid: orderid
                     }
                 });
-                this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                this.assetForm.purchaseData = response.data.purchaseOrderItems;
-                this.assetForm.orderId = row.orderDbId;
-                this.assetForm.purchaseOrderType = 'C';
-                console.log(this.currentEditPurchaseOrderRid);
+                this.currentCutModelType = response2.data.cutModelType;
             }
         },
         updateNewPurchaseData(updatedItems) {
-            this.assetForm.purchaseData = [...updatedItems]
-
+            this.assetForm.purchaseData = [...updatedItems]; // Ensures Vue detects the change
+            console.log("Updated purchaseData:", this.assetForm.purchaseData);
         },
-        savecutModelPurchaseOrder() {
+        saveCutModelPurchaseOrder() {
             this.$refs.purchaseForm.validate(async (valid) => {
                 if (valid) {
                     if (this.assetForm.purchaseData.length === 0) {
@@ -416,26 +475,26 @@ export default {
                         console.log(this.assetForm)
                         if (this.createEditSymbol === 1) {
                             await axios.post(
-                                `${this.$apiBaseUrl}/logistics/editsavedcutmodelpurchaseorderitems`,
+                                `${this.$apiBaseUrl}/logistics/editsavedcutModelpurchaseorderitems`,
                                 {
                                     data: this.assetForm.purchaseData,
                                     purchaseOrderRId: this.currentEditPurchaseOrderRid,
                                     orderId: this.assetForm.orderId,
                                     orderShoeId: this.assetForm.orderShoeId,
-                                    batchInfoType : this.assetForm.batchInfoType,
+                                    batchInfoType: this.assetForm.batchInfoType,
                                     purchaseOrderType: this.assetForm.purchaseOrderType
                                 }
                             )
                         }
                         else {
                             await axios.post(
-                                `${this.$apiBaseUrl}/logistics/newcutmodelpurchaseordersave`,
+                                `${this.$apiBaseUrl}/logistics/newcutModelpurchaseordersave`,
                                 {
                                     data: this.assetForm.purchaseData,
                                     purchaseOrderRId: this.currentEditPurchaseOrderRid,
                                     orderId: this.assetForm.orderId,
                                     orderShoeId: this.assetForm.orderShoeId,
-                                    batchInfoType : this.assetForm.batchInfoType,
+                                    batchInfoType: this.assetForm.batchInfoType,
                                     purchaseOrderType: this.assetForm.purchaseOrderType
                                 }
                             )
@@ -443,7 +502,7 @@ export default {
                         ElMessage.success('保存成功')
 
                         // Close the current page
-                        }
+                    }
                     catch (error) {
                         console.log(error)
                         ElMessage.error("保存失败")
@@ -454,14 +513,98 @@ export default {
                 }
             })
         },
-
+        confirmPurchaseDivideOrderSave() {
+            this.$confirm('确定保存此分采购订单吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.submitPurchaseDivideOrderSave()
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消保存'
+                    })
+                })
+        },
+        confirmPurchaseDivideOrderSubmit() {
+            this.$confirm('确定提交此分采购订单吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.submitPurchaseDivideOrder()
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消提交'
+                    })
+                })
+        },
+        async submitPurchaseDivideOrderSave() {
+            const loadingInstance = this.$loading({
+                lock: true,
+                text: '等待中，请稍后...',
+                background: 'rgba(0, 0, 0, 0.7)'
+            })
+            const response = await this.$axios.post(
+                `${this.$apiBaseUrl}/firstpurchase/savepurchasedivideorders`,
+                {
+                    purchaseOrderId: this.currentEditPurchaseOrderId,
+                    purchaseDivideOrders: this.tabPlaneData
+                }
+            )
+            loadingInstance.close()
+            if (response.status !== 200) {
+                this.$message({
+                    type: 'error',
+                    message: '保存失败'
+                })
+                return
+            }
+            this.$message({
+                type: 'success',
+                message: '保存成功'
+            })
+            this.purchaseOrderCreateVis = false
+        },
+        async submitPurchaseDivideOrder() {
+            const loadingInstance = this.$loading({
+                lock: true,
+                text: '等待中，请稍后...',
+                background: 'rgba(0, 0, 0, 0.7)'
+            })
+            const response = await this.$axios.post(
+                `${this.$apiBaseUrl}/logistics/submitindividualpurchaseorders`,
+                {
+                    purchaseOrderId: this.currentEditPurchaseOrderId
+                }
+            )
+            loadingInstance.close()
+            if (response.status !== 200) {
+                this.$message({
+                    type: 'error',
+                    message: '提交失败'
+                })
+                return
+            }
+            this.$message({
+                type: 'success',
+                message: '提交成功'
+            })
+            this.purchaseOrderCreateVis = false
+        },
         handleFilter() {
             this.currentPage = 1;
             this.filteredList = this.orderList.filter(order => {
                 return (
                     (!this.orderSearch || order.orderRid.includes(this.orderSearch)) &&
                     (!this.customerSearch || order.customerName.includes(this.customerSearch)) &&
-                    (order.orderCuttingModelStatus === this.orderCuttingModelStatus)
+                    (order.orderCutModelStatus === this.orderCutModelStatus)
                 );
             });
         },
@@ -471,7 +614,24 @@ export default {
         },
         handleCurrentChange(newPage) {
             this.currentPage = newPage;
-        }
+        },
+        jumpOverCutModelPurchase() {
+        },
+        factoryFieldJudge(field) {
+            if (field === 'N') {
+                return false
+            }
+            return true
+        },
+        async getBatchTypeList() {
+            const response = await axios.get(`${this.$apiBaseUrl}/shoe/getshoebatchinfotypebysizetable`, {
+                params: {
+                    orderId: this.orderid
+                }
+            })
+            console.log(response.data)
+            this.sizeLabelColumns = response.data
+        },
     }
 }
 </script>

--- a/frontend/jiancheng/src/components/LastPurchaseView.vue
+++ b/frontend/jiancheng/src/components/LastPurchaseView.vue
@@ -3,110 +3,53 @@
         <el-main style="height: 100vh;">
             <el-row :gutter="20" style="text-align: center;">
                 <el-col :span="24" :offset="0" style="font-size: xx-large; text-align: center;">
-                    {{ `楦头采购` }}
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="1" :offset="0">
-                    <el-text style="white-space: nowrap;">订单筛选：</el-text>
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-input v-model="orderSearch" placeholder="请输入订单号" clearable @input="handleFilter"></el-input>        
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-input v-model="customerSearch" placeholder="请输入客户名" clearable @input="handleFilter"></el-input>
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-radio-group v-model="orderLastStatus" size="medium" @change="handleFilter">
-                        <el-radio-button label="0">未采购</el-radio-button>
-                        <el-radio-button label="1">已保存</el-radio-button>
-                        <el-radio-button label="2">已采购</el-radio-button>
-                    </el-radio-group>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-table :data="paginatedList" border stripe height="250" style="width: 100%">
-                        <el-table-column prop="orderRid" label="订单号"></el-table-column>
-                        <el-table-column prop="orderCid" label="客户订单号"></el-table-column>
-                        <el-table-column prop="customerName" label="客户名"></el-table-column>
-                        <el-table-column prop="orderStartDate" label="下单日期"></el-table-column>
-                        <el-table-column prop="orderStatus" label="订单状态"></el-table-column>
-                        <el-table-column prop="orderLastStatus" label="楦头采购状态" :formatter="lastStatusFormatter"></el-table-column>
-                        <el-table-column label="操作" width="400">
-                            <template #default="scope">
-                                <div v-if="scope.row.orderLastStatus === '0'">
-                                    <el-button type="primary" size="mini" @click="openSizeComparisonDialog(scope.row)">查看开发部尺码对照表</el-button>
-                                    <el-button type="primary" size="mini" @click="createLastPurchaseOrder(scope.row)">创建楦头采购订单</el-button>
-                                </div>
-                                <div v-else-if="scope.row.orderLastStatus === '1'">
-                                    <el-button type="primary" size="mini" @click="openSizeComparisonDialog(scope.row)">查看开发部尺码对照表</el-button>
-                                    <el-button type="primary" size="mini" @click="editLastPurchaseOrder(scope.row)">编辑楦头采购订单</el-button>
-                                </div>
-                                <div v-else>
-                                    <el-button type="primary" size="mini" @click="openSizeComparisonDialog(scope.row)">查看开发部尺码对照表</el-button>
-                                </div>
-                            </template>
-                        </el-table-column>
-                    </el-table>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-pagination
-                        @size-change="handleSizeChange"
-                        @current-change="handleCurrentChange"
-                        :current-page="currentPage"
-                        :page-sizes="[10, 20, 30, 40]"
-                        :page-size="pageSize"
-                        layout="total, sizes, prev, pager, next, jumper"
-                        :total="filteredList.length">
-                    </el-pagination>
+                    {{ `楦头采购 ${currentOrderRid} ${currentEditPurchaseOrderRid}` }}
                 </el-col>
             </el-row>
             <el-divider></el-divider>
             <el-row :gutter="20">
                 <el-col :span="8" :offset="0" :key="currentEditPurchaseOrderRid">
-                    采购订单创建 {{ currentEditPurchaseOrderRid }}
+                    楦头信息
                 </el-col>
             </el-row>
             <el-row :gutter="20">
                 <el-col :span="12" :offset="6">
-                    <el-descriptions border>
+                    <el-descriptions border column="3">
                         <el-descriptions-item label="楦头类型">{{ currentLastType }}</el-descriptions-item>
                         <el-descriptions-item label="楦头库存信息">
-                            <el-button type="primary" size="default" @click="openLastSearchDialog" :disabled="currentEditPurchaseOrderRid===''">楦头查询</el-button>
-                            
+                            <el-button type="primary" size="default" @click="openLastSearchDialog"
+                                :disabled="currentEditPurchaseOrderRid === ''">楦头查询</el-button>
+                        </el-descriptions-item>
+                        <el-descriptions-item label="订单尺码对照表">
+                            <el-button type="primary" size="default" @click="openSizeComparisonDialog"
+                                :disabled="currentEditPurchaseOrderRid === ''">查看</el-button>
                         </el-descriptions-item>
                     </el-descriptions>
                 </el-col>
             </el-row>
             <div v-if="currentEditPurchaseOrderRid !== ''">
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-form ref="purchaseForm" :model="assetForm" :rules="rules">
-                        <purchase-items-table 
-                            :material-type-options="materialTypeOptions" 
-                            @update-items="updateNewPurchaseData"
-                            :batch-info-visible="1"
-                            :purchaseData.sync="assetForm.purchaseData"
-                            :type-limit="[12]"
-                        ></purchase-items-table>
-                    </el-form>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="4" :offset="22">
-                    <el-button type="primary" size="medium" @click="saveLastPurchaseOrder" :disabled="currentEditPurchaseOrderRid === ''">保存采购订单</el-button>
+                <el-row :gutter="20">
+                    <el-col :span="24" :offset="0">
+                        <el-form ref="purchaseForm" :model="assetForm" :rules="rules">
+                            <purchase-items-table :material-type-options="materialTypeOptions"
+                                @update-items="updateNewPurchaseData" :purchase-data="assetForm.purchaseData"
+                                :type-limit="[12]" :order-id="orderid"></purchase-items-table>
+                        </el-form>
+                    </el-col>
+                </el-row>
+                <el-row :gutter="20">
+                    <el-col :span="8" :offset="18">
+                        <el-button type="primary" size="medium" @click="saveLastPurchaseOrder"
+                            :disabled="currentEditPurchaseOrderRid === ''">保存采购订单</el-button>
+                        <el-button type="warning" size="medium" @click="openSubmitDialog"
+                            :disabled="currentEditPurchaseOrderRid === ''">提交采购订单</el-button>
+                        <el-button type="danger" size="default" @click="jumpOverLastPurchase">利用库存，无需采购</el-button>
 
-                </el-col>
-            </el-row>
-        </div>
+                    </el-col>
+                </el-row>
+            </div>
         </el-main>
-        <el-dialog
-            :title="`订单 ${currentOrderRid} 开发部尺码对照表`"
-            v-model="isSizeComparisonDialogVisible"
-            width="80%"
+        <el-dialog :title="`订单 ${currentOrderRid} 开发部尺码对照表`" v-model="isSizeComparisonDialogVisible" width="80%"
             draggable="true">
             <span>
                 <el-row justify="center" align="middle">
@@ -121,16 +64,13 @@
                 </el-row>
             </span>
             <template #footer>
-            <span>
-                <el-button @click="isSizeComparisonDialogVisible = false">Cancel</el-button>
-                <el-button type="primary" @click="">OK</el-button>
-            </span>
+                <span>
+                    <el-button @click="isSizeComparisonDialogVisible = false">Cancel</el-button>
+                    <el-button type="primary" @click="">OK</el-button>
+                </span>
             </template>
         </el-dialog>
-        <el-dialog
-            title="楦头库存信息查询"
-            v-model="isLastSearchDialogVisable"
-            width="80%">
+        <el-dialog title="楦头库存信息查询" v-model="isLastSearchDialogVisable" width="80%">
             <span>
                 <el-input v-model="lastNameSearch" placeholder="请输入楦头型号" clearable @change="searchLast"></el-input>
                 <el-table :data="filteredMaterialList" border stripe style="width: 100%">
@@ -138,23 +78,98 @@
                     <el-table-column prop="materialModel" label="材料型号"></el-table-column>
                     <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
                     <el-table-column prop="purchaseAmount" label="采购数量" />
-                                    <el-table-column :label="`分码数量 (${currentShoeSizeType})`">
-                                        <el-table-column v-for="column in filteredColumns(
-                                            filteredMaterialList
-                                        )" :key="column.prop" :prop="column.prop"
-                                            :label="column.label"></el-table-column>
-                                    </el-table-column>
+                    <el-table-column :label="`分码数量 (${currentShoeSizeType})`">
+                        <el-table-column v-for="column in filteredColumns(
+                            filteredMaterialList
+                        )" :key="column.prop" :prop="column.prop" :label="column.label"></el-table-column>
+                    </el-table-column>
                 </el-table>
             </span>
             <template #footer>
-            <span>
-                <el-button @click="isLastSearchDialogVisable = false">Cancel</el-button>
-                <el-button type="primary" @click="">OK</el-button>
-            </span>
+                <span>
+                    <el-button @click="isLastSearchDialogVisable = false">Cancel</el-button>
+                    <el-button type="primary" @click="">OK</el-button>
+                </span>
             </template>
         </el-dialog>
-        
-        
+        <el-dialog title="采购订单创建页面" v-model="purchaseOrderCreateVis" width="80%" :close-on-click-modal="false">
+            <span v-if="activeTab === ''"> 无需购买材料，推进流程即可。 </span>
+            <el-tabs v-if="activeTab !== ''" v-model="activeTab" type="card" tab-position="top">
+                <el-tab-pane v-for="(item, index) in tabPlaneData" :key="index"
+                    :label="item.purchaseDivideOrderId + '    ' + item.supplierName" :name="item.purchaseDivideOrderId"
+                    style="min-height: 500px">
+                    <el-row :gutter="20">
+                        <el-col :span="12" :offset="0"><span>订单备注：
+                                <el-input v-model="item.remark" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input> </span></el-col>
+                        <el-col :span="12" :offset="0">
+                            <span>环境要求：
+                                <el-input v-model="item.evironmentalRequest" placeholder="" type="textarea"
+                                    resize="none" clearable></el-input>
+                            </span>
+                        </el-col>
+                    </el-row>
+                    <el-row :gutter="20">
+                        <el-col :span="12" :offset="0">
+                            <span>发货地址：
+                                <el-input v-model="item.shipmentAddress" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input>
+                            </span>
+                        </el-col>
+                        <el-col :span="12" :offset="0">
+                            <span>交货周期：
+                                <el-input v-model="item.shipmentDeadline" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input>
+                            </span>
+                        </el-col>
+                    </el-row>
+                    <el-row :gutter="20" style="margin-top: 20px">
+                        <el-col :span="24" :offset="0">
+                            <div v-if="factoryFieldJudge(item.purchaseDivideOrderType)">
+                                <el-table :data="item.assetsItems" border style="width: 100%" height="500">
+                                    <el-table-column type="index" label="编号" />
+                                    <el-table-column prop="materialType" label="材料类型"></el-table-column>
+                                    <el-table-column prop="materialName" label="材料名称" />
+                                    <el-table-column prop="materialModel" label="材料型号" />
+                                    <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
+                                    <el-table-column prop="unit" label="单位" />
+
+                                    <el-table-column prop="purchaseAmount" label="采购数量" />
+                                    <el-table-column :label="`分码数量`">
+                                        <el-table-column v-for="column in filteredColumns(item.assetsItems)"
+                                            :key="column.prop" :prop="column.prop"
+                                            :label="column.label"></el-table-column>
+                                    </el-table-column>
+                                </el-table>
+                            </div>
+                            <div v-else>
+                                <el-table :data="item.assetsItems" border stripe height="500">
+                                    <el-table-column type="index"></el-table-column>
+                                    <el-table-column prop="materialType" label="材料类型"></el-table-column>
+                                    <el-table-column prop="materialName" label="材料名称" />
+                                    <el-table-column prop="materialModel" label="材料型号" />
+                                    <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
+                                    <el-table-column prop="color" label="颜色" />
+                                    <el-table-column prop="unit" label="单位" />
+                                    <el-table-column prop="purchaseAmount" label="数量" />
+                                    <el-table-column prop="remark" label="开发部备注" />
+                                </el-table>
+                            </div>
+                        </el-col>
+                    </el-row>
+                </el-tab-pane>
+            </el-tabs>
+
+            <template #footer>
+                <span>
+                    <el-button @click="purchaseOrderCreateVis = false">取消</el-button>
+                    <el-button type="primary" @click="confirmPurchaseDivideOrderSave">保存</el-button>
+                    <el-button type="success" @click="confirmPurchaseDivideOrderSubmit">提交</el-button>
+                </span>
+            </template>
+        </el-dialog>
+
+
     </el-container>
 </template>
 
@@ -164,12 +179,16 @@ import PurchaseItemsTable from '@/Pages/LogisticsControlDepartment/LogisticsCont
 import { ElMessage } from 'element-plus';
 import { getShoeSizesName } from '@/Pages/utils/getShoeSizesName'
 export default {
+    props: ['orderid'],
     components: {
         PurchaseItemsTable
     },
     data() {
         return {
             getShoeSizesName,
+            purchaseOrderCreateVis: false,
+            activeTab: '',
+            tabPlaneData: [],
             isLastSearchDialogVisable: false,
             isSizeComparisonDialogVisible: false,
             orderSearch: '',
@@ -188,6 +207,7 @@ export default {
             currentEditPurchaseOrderId: 0,
             createEditSymbol: 0,
             currentShoeSizeType: '',
+            currentOrderDBId: 0,
             sizeGridOptions: [],
             shoeSizeColumns: [],
             sizeLabelColumns: [],
@@ -221,7 +241,9 @@ export default {
                                 callback(new Error("尚未选择订单鞋型"));
                             } else {
                                 callback();
+
                             }
+
                         },
                         trigger: "change",
                     },
@@ -236,10 +258,64 @@ export default {
         }
     },
     mounted() {
-        this.getAllOrders();
+        this.getOrderInfo(this.orderid);
         this.getAllMaterialTypes();
+        this.getCurrentPurchaseOrder();
+        this.getBatchTypeList();
+
     },
     methods: {
+        async getCurrentPurchaseOrder() {
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/getlastpurchaseorderitems`, {
+                params: {
+                    orderid: this.orderid
+                }
+            });
+            this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid || '';
+            this.currentEditPurchaseOrderId = response.data.purchaseOrderId || null;
+            this.assetForm.purchaseData = response.data.purchaseOrderItems;
+            this.assetForm.orderId = this.orderid;
+            this.assetForm.purchaseOrderType = 'L';
+            const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getlastinfo`, {
+                params: {
+                    orderid: this.orderid
+                }
+            });
+            this.currentLastType = response2.data.lastType;
+            if (this.currentEditPurchaseOrderId === null) {
+                {
+                    this.createLastPurchaseOrder(this.orderid)
+                }
+            }
+            else {
+                this.createEditSymbol = 1
+            }
+        },
+        async openSubmitDialog() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/logistics/getindividualpurchaseorders`,
+                {
+                    params: {
+                        purchaseOrderId: this.currentEditPurchaseOrderId
+                    }
+                }
+            )
+            this.tabPlaneData = response.data
+            console.log(this.tabPlaneData)
+            if (this.tabPlaneData.length > 0) {
+                this.activeTab = this.tabPlaneData[0].purchaseDivideOrderId
+            }
+            this.purchaseOrderCreateVis = true
+        },
+        async getOrderInfo(orderId) {
+            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo`, {
+                params: {
+                    orderid: orderId
+                }
+            });
+            this.currentOrderRid = response.data.orderId;
+            this.currentOrderDBId = response.data.orderDBId;
+        },
         async getAllOrders() {
             try {
                 const response = await axios.get(`${this.$apiBaseUrl}/order/getallorders`);
@@ -276,34 +352,40 @@ export default {
                 }
             });
             this.filteredMaterialList = response.data.data;
-            
+
         },
-        async openSizeComparisonDialog(row) {
-            this.currentOrderRid = row.orderRid;
-            await this.getSizeTableData(row);
+        async openSizeComparisonDialog() {
+            await this.getSizeTableData();
             this.sizeGridOptions.editConfig = false;
             for (let item of this.sizeGridOptions.columns) {
                 item.width = 125;
             }
             this.isSizeComparisonDialogVisible = true;
         },
-        async getSizeTableData(row) {
+        async getSizeTableData() {
             const response = await axios.get(
-                `${this.$apiBaseUrl}/devproductionorder/getsizetable?orderId=${row.orderDbId}`
+                `${this.$apiBaseUrl}/devproductionorder/getsizetable?orderId=${this.currentOrderDBId}`
             )
 
             this.sizeGridOptions = response.data
             console.log(this.sizeGridOptions)
         },
         filteredColumns(array) {
-            return this.shoeSizeColumns.filter((column) =>
-                array.some(
-                    (row) =>
-                        row[column.prop] !== undefined &&
-                        row[column.prop] !== null &&
-                        row[column.prop] !== 0
-                )
-            )
+            if (!array || !this.sizeLabelColumns) return [];
+
+            return Object.keys(this.sizeLabelColumns)
+                .map((slotKey) => {
+                    const amountKey = slotKey.replace("Slot", "Amount"); // Convert size34Slot → size34Amount
+
+                    if (array.some(row => row[amountKey] !== undefined && row[amountKey] !== 0)) {
+                        return {
+                            prop: amountKey,
+                            label: this.sizeLabelColumns[slotKey] // Use size number (e.g., "34", "35")
+                        };
+                    }
+                    return null;
+                })
+                .filter(column => column !== null); // Remove null values
         },
         lastStatusFormatter(row) {
             switch (row.orderLastStatus) {
@@ -315,109 +397,53 @@ export default {
                     return '已采购';
             }
         },
-        async createLastPurchaseOrder(row) {
-            if (this.currentEditPurchaseOrderRid != '') {
-                this.$confirm('当前有未保存的采购订单，是否放弃编辑?', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(async () => {
-                    this.currentEditPurchaseOrderRid = '';
-                    const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewlastpurchaseorderid`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                    this.createEditSymbol = 0;
-                    this.assetForm.purchaseData = [];
-                    this.assetForm.orderId = row.orderDbId;
-                    this.assetForm.purchaseOrderType = 'L';
-                    console.log(this.currentEditPurchaseOrderRid);
-                    const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getlastinfo`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentLastType = response2.data.lastType;
-                    return
-                }).catch(() => {
-                    return;
+        async createLastPurchaseOrder(orderid) {
+            console.log(this.currentEditPurchaseOrderRid);
+            if (this.currentEditPurchaseOrderRid !== '') {
+                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getlastpurchaseorderitems`, {
+                    params: {
+                        orderid: orderid
+                    }
                 });
+                this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
+                this.currentEditPurchaseOrderId = response.data.purchaseOrderId;
+                console.log(response.data.purchaseOrderItems)
+                this.assetForm.purchaseData = response.data.purchaseOrderItems;
+                this.assetForm.orderId = orderid;
+                this.assetForm.purchaseOrderType = 'L';
+                console.log(this.assetForm)
+                console.log(this.currentEditPurchaseOrderRid);
+                const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getlastinfo`, {
+                    params: {
+                        orderid: orderid
+                    }
+                });
+                this.currentLastType = response2.data.lastType;
+                this.createEditSymbol = 1
             }
             else {
                 const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewlastpurchaseorderid`, {
                     params: {
-                        orderid: row.orderDbId
+                        orderid: orderid
                     }
                 });
                 this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
                 this.createEditSymbol = 0;
                 this.assetForm.purchaseData = [];
-                this.assetForm.orderId = row.orderDbId;
+                this.assetForm.orderId = orderid;
                 this.assetForm.purchaseOrderType = 'L';
                 console.log(this.currentEditPurchaseOrderRid);
                 const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getlastinfo`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentLastType = response2.data.lastType;
-            }
-        },
-        async editLastPurchaseOrder(row) {
-            if (this.currentEditPurchaseOrderRid != '') {
-                this.$confirm('当前有未保存的采购订单，是否放弃编辑?', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(async () => {
-                    this.currentEditPurchaseOrderRid = '';
-                    const response = await axios.get(`${this.$apiBaseUrl}/logistics/getlastpurchaseorderitems`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                    this.createEditSymbol = 1;
-                    this.assetForm.purchaseData = response.data.purchaseOrderItems;
-                    this.assetForm.orderId = row.orderDbId;
-                    this.assetForm.purchaseOrderType = 'L';
-                    console.log(this.currentEditPurchaseOrderRid);
-                    const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getlastinfo`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentLastType = response2.data.lastType;
-                    return
-                }).catch(() => {
-                    return;
-                });
-            }
-            else {
-                this.createEditSymbol = 1;
-                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getlastpurchaseorderitems`, {
                     params: {
-                        orderid: row.orderDbId
+                        orderid: orderid
                     }
                 });
-                this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                this.assetForm.purchaseData = response.data.purchaseOrderItems;
-                this.assetForm.orderId = row.orderDbId;
-                this.assetForm.purchaseOrderType = 'L';
-                console.log(this.currentEditPurchaseOrderRid);
-                const response2 = await axios.get(`${this.$apiBaseUrl}/logistics/getlastinfo`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentLastType = response2.data.lastType;
+                this.currentLastType = response2.data.lastType;
             }
         },
         updateNewPurchaseData(updatedItems) {
-            this.assetForm.purchaseData = [...updatedItems]
-
+            this.assetForm.purchaseData = [...updatedItems]; // Ensures Vue detects the change
+            console.log("Updated purchaseData:", this.assetForm.purchaseData);
         },
         saveLastPurchaseOrder() {
             this.$refs.purchaseForm.validate(async (valid) => {
@@ -448,7 +474,7 @@ export default {
                                     purchaseOrderRId: this.currentEditPurchaseOrderRid,
                                     orderId: this.assetForm.orderId,
                                     orderShoeId: this.assetForm.orderShoeId,
-                                    batchInfoType : this.assetForm.batchInfoType,
+                                    batchInfoType: this.assetForm.batchInfoType,
                                     purchaseOrderType: this.assetForm.purchaseOrderType
                                 }
                             )
@@ -461,7 +487,7 @@ export default {
                                     purchaseOrderRId: this.currentEditPurchaseOrderRid,
                                     orderId: this.assetForm.orderId,
                                     orderShoeId: this.assetForm.orderShoeId,
-                                    batchInfoType : this.assetForm.batchInfoType,
+                                    batchInfoType: this.assetForm.batchInfoType,
                                     purchaseOrderType: this.assetForm.purchaseOrderType
                                 }
                             )
@@ -469,7 +495,7 @@ export default {
                         ElMessage.success('保存成功')
 
                         // Close the current page
-                        }
+                    }
                     catch (error) {
                         console.log(error)
                         ElMessage.error("保存失败")
@@ -478,9 +504,95 @@ export default {
                 else {
                     console.log("validation error")
                 }
+                //refresh the page
+                this.getCurrentPurchaseOrder();
             })
         },
-
+        confirmPurchaseDivideOrderSave() {
+            this.$confirm('确定保存此分采购订单吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.submitPurchaseDivideOrderSave()
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消保存'
+                    })
+                })
+        },
+        confirmPurchaseDivideOrderSubmit() {
+            this.$confirm('确定提交此分采购订单吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.submitPurchaseDivideOrder()
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消提交'
+                    })
+                })
+        },
+        async submitPurchaseDivideOrderSave() {
+            const loadingInstance = this.$loading({
+                lock: true,
+                text: '等待中，请稍后...',
+                background: 'rgba(0, 0, 0, 0.7)'
+            })
+            const response = await this.$axios.post(
+                `${this.$apiBaseUrl}/firstpurchase/savepurchasedivideorders`,
+                {
+                    purchaseOrderId: this.currentEditPurchaseOrderId,
+                    purchaseDivideOrders: this.tabPlaneData
+                }
+            )
+            loadingInstance.close()
+            if (response.status !== 200) {
+                this.$message({
+                    type: 'error',
+                    message: '保存失败'
+                })
+                return
+            }
+            this.$message({
+                type: 'success',
+                message: '保存成功'
+            })
+            this.purchaseOrderCreateVis = false
+        },
+        async submitPurchaseDivideOrder() {
+            const loadingInstance = this.$loading({
+                lock: true,
+                text: '等待中，请稍后...',
+                background: 'rgba(0, 0, 0, 0.7)'
+            })
+            const response = await this.$axios.post(
+                `${this.$apiBaseUrl}/logistics/submitindividualpurchaseorders`,
+                {
+                    purchaseOrderId: this.currentEditPurchaseOrderId
+                }
+            )
+            loadingInstance.close()
+            if (response.status !== 200) {
+                this.$message({
+                    type: 'error',
+                    message: '提交失败'
+                })
+                return
+            }
+            this.$message({
+                type: 'success',
+                message: '提交成功'
+            })
+            this.purchaseOrderCreateVis = false
+        },
         handleFilter() {
             this.currentPage = 1;
             this.filteredList = this.orderList.filter(order => {
@@ -497,7 +609,54 @@ export default {
         },
         handleCurrentChange(newPage) {
             this.currentPage = newPage;
-        }
+        },
+        jumpOverLastPurchase() {
+            this.$confirm('确定利用库存，无需采购吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.$axios.post(`${this.$apiBaseUrl}/logistics/jumpoverlastpurchase`, {
+                        orderId: this.orderid
+                    })
+                        .then(() => {
+                            this.$message({
+                                type: 'success',
+                                message: '操作成功'
+                            })
+                            // Close the current page
+                            window.close()
+                        })
+                        .catch(() => {
+                            this.$message({
+                                type: 'error',
+                                message: '操作失败'
+                            })
+                        })
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消'
+                    })
+                })
+        },
+        factoryFieldJudge(field) {
+            if (field === 'N') {
+                return false
+            }
+            return true
+        },
+        async getBatchTypeList() {
+            const response = await axios.get(`${this.$apiBaseUrl}/shoe/getshoebatchinfotypebysizetable`, {
+                params: {
+                    orderId: this.orderid
+                }
+            })
+            console.log(response.data)
+            this.sizeLabelColumns = response.data
+        },
     }
 }
 </script>

--- a/frontend/jiancheng/src/components/PackagePurchaseView.vue
+++ b/frontend/jiancheng/src/components/PackagePurchaseView.vue
@@ -3,98 +3,122 @@
         <el-main style="height: 100vh;">
             <el-row :gutter="20" style="text-align: center;">
                 <el-col :span="24" :offset="0" style="font-size: xx-large; text-align: center;">
-                    {{ `包材采购` }}
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="1" :offset="0">
-                    <el-text style="white-space: nowrap;">订单筛选：</el-text>
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-input v-model="orderSearch" placeholder="请输入订单号" clearable @input="handleFilter"></el-input>        
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-input v-model="customerSearch" placeholder="请输入客户名" clearable @input="handleFilter"></el-input>
-                </el-col>
-                <el-col :span="4" :offset="0">
-                    <el-radio-group v-model="orderPackagingStatus" size="medium" @change="handleFilter">
-                        <el-radio-button label="0">未采购</el-radio-button>
-                        <el-radio-button label="1">已保存</el-radio-button>
-                        <el-radio-button label="2">已采购</el-radio-button>
-                    </el-radio-group>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-table :data="paginatedList" border stripe height="250" style="width: 100%">
-                        <el-table-column prop="orderRid" label="订单号"></el-table-column>
-                        <el-table-column prop="orderCid" label="客户订单号"></el-table-column>
-                        <el-table-column prop="customerName" label="客户名"></el-table-column>
-                        <el-table-column prop="orderStartDate" label="下单日期"></el-table-column>
-                        <el-table-column prop="orderStatus" label="订单状态"></el-table-column>
-                        <el-table-column prop="orderPackagingStatus" label="包材采购状态" :formatter="packageStatusFormatter"></el-table-column>
-                        <el-table-column label="操作" width="400">
-                            <template #default="scope">
-                                <div v-if="scope.row.orderPackagingStatus === '0'">
-                                    <el-button type="primary" size="mini" @click="viewPackagingInfo(scope.row)">查看包装资料</el-button>
-                                    <el-button type="primary" size="mini" @click="createPackagePurchaseOrder(scope.row)">创建包装材料采购订单</el-button>
-                                </div>
-                                <div v-else-if="scope.row.orderPackagingStatus === '1'">
-                                    <el-button type="primary" size="mini" @click="viewPackagingInfo(scope.row)">查看包装资料</el-button>
-                                    <el-button type="primary" size="mini" @click="editPackagePurchaseOrder(scope.row)">编辑包装材料采购订单</el-button>
-                                </div>
-                                <div v-else>
-                                    <el-button type="primary" size="mini" @click="viewPackagingInfo(scope.row)">查看包装资料</el-button>
-                                </div>
-                            </template>
-                        </el-table-column>
-                    </el-table>
-                </el-col>
-            </el-row>
-            <el-row :gutter="20">
-                <el-col :span="24" :offset="0">
-                    <el-pagination
-                        @size-change="handleSizeChange"
-                        @current-change="handleCurrentChange"
-                        :current-page="currentPage"
-                        :page-sizes="[10, 20, 30, 40]"
-                        :page-size="pageSize"
-                        layout="total, sizes, prev, pager, next, jumper"
-                        :total="filteredList.length">
-                    </el-pagination>
+                    {{ `包装采购 ${currentOrderRid} ${currentEditPurchaseOrderRid}` }}
                 </el-col>
             </el-row>
             <el-divider></el-divider>
             <el-row :gutter="20">
                 <el-col :span="8" :offset="0" :key="currentEditPurchaseOrderRid">
-                    采购订单创建 {{ currentEditPurchaseOrderRid }}
+                    包装信息
+                </el-col>
+            </el-row>
+            <el-row :gutter="20">
+                <el-col :span="12" :offset="6">
+                    <el-descriptions border column="3">
+                        <el-descriptions-item label="包装信息">
+                            <el-button type="primary" size="default" @click="viewPackagingInfo"
+                                :disabled="currentEditPurchaseOrderRid === ''">查看</el-button>
+                        </el-descriptions-item>
+                    </el-descriptions>
                 </el-col>
             </el-row>
             <div v-if="currentEditPurchaseOrderRid !== ''">
                 <el-row :gutter="20">
                     <el-col :span="24" :offset="0">
                         <el-form ref="purchaseForm" :model="assetForm" :rules="rules">
-                            <purchase-items-table 
-                                :material-type-options="materialTypeOptions" 
-                                @update-items="updateNewPurchaseData"
-                                :batch-info-visible="0"
-                                :purchaseData.sync="assetForm.purchaseData"
-                                :type-limit="[6]"
-                            ></purchase-items-table>
+                            <purchase-items-table :material-type-options="materialTypeOptions"
+                                @update-items="updateNewPurchaseData" :purchase-data="assetForm.purchaseData"
+                                :type-limit="[6]" :order-id="orderid"></purchase-items-table>
                         </el-form>
                     </el-col>
                 </el-row>
                 <el-row :gutter="20">
-                    <el-col :span="4" :offset="22">
-                        <el-button type="primary" size="medium" @click="savePackagePurchaseOrder" :disabled="currentEditPurchaseOrderRid === ''">保存采购订单</el-button>
+                    <el-col :span="8" :offset="18">
+                        <el-button type="primary" size="medium" @click="savePackagePurchaseOrder"
+                            :disabled="currentEditPurchaseOrderRid === ''">保存采购订单</el-button>
+                        <el-button type="warning" size="medium" @click="openSubmitDialog"
+                            :disabled="currentEditPurchaseOrderRid === ''">提交采购订单</el-button>
 
                     </el-col>
                 </el-row>
             </div>
-            
-            
-            
         </el-main>
+        <el-dialog title="采购订单创建页面" v-model="purchaseOrderCreateVis" width="80%" :close-on-click-modal="false">
+            <span v-if="activeTab === ''"> 无需购买材料，推进流程即可。 </span>
+            <el-tabs v-if="activeTab !== ''" v-model="activeTab" type="card" tab-position="top">
+                <el-tab-pane v-for="(item, index) in tabPlaneData" :key="index"
+                    :label="item.purchaseDivideOrderId + '    ' + item.supplierName" :name="item.purchaseDivideOrderId"
+                    style="min-height: 500px">
+                    <el-row :gutter="20">
+                        <el-col :span="12" :offset="0"><span>订单备注：
+                                <el-input v-model="item.remark" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input> </span></el-col>
+                        <el-col :span="12" :offset="0">
+                            <span>环境要求：
+                                <el-input v-model="item.evironmentalRequest" placeholder="" type="textarea"
+                                    resize="none" clearable></el-input>
+                            </span>
+                        </el-col>
+                    </el-row>
+                    <el-row :gutter="20">
+                        <el-col :span="12" :offset="0">
+                            <span>发货地址：
+                                <el-input v-model="item.shipmentAddress" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input>
+                            </span>
+                        </el-col>
+                        <el-col :span="12" :offset="0">
+                            <span>交货周期：
+                                <el-input v-model="item.shipmentDeadline" placeholder="" type="textarea" resize="none"
+                                    clearable></el-input>
+                            </span>
+                        </el-col>
+                    </el-row>
+                    <el-row :gutter="20" style="margin-top: 20px">
+                        <el-col :span="24" :offset="0">
+                            <div v-if="factoryFieldJudge(item.purchaseDivideOrderType)">
+                                <el-table :data="item.assetsItems" border style="width: 100%" height="500">
+                                    <el-table-column type="index" label="编号" />
+                                    <el-table-column prop="materialType" label="材料类型"></el-table-column>
+                                    <el-table-column prop="materialName" label="材料名称" />
+                                    <el-table-column prop="materialModel" label="材料型号" />
+                                    <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
+                                    <el-table-column prop="unit" label="单位" />
+
+                                    <el-table-column prop="purchaseAmount" label="采购数量" />
+                                    <el-table-column :label="`分码数量`">
+                                        <el-table-column v-for="column in filteredColumns(item.assetsItems)"
+                                            :key="column.prop" :prop="column.prop"
+                                            :label="column.label"></el-table-column>
+                                    </el-table-column>
+                                </el-table>
+                            </div>
+                            <div v-else>
+                                <el-table :data="item.assetsItems" border stripe height="500">
+                                    <el-table-column type="index"></el-table-column>
+                                    <el-table-column prop="materialType" label="材料类型"></el-table-column>
+                                    <el-table-column prop="materialName" label="材料名称" />
+                                    <el-table-column prop="materialModel" label="材料型号" />
+                                    <el-table-column prop="materialSpecification" label="材料规格"></el-table-column>
+                                    <el-table-column prop="color" label="颜色" />
+                                    <el-table-column prop="unit" label="单位" />
+                                    <el-table-column prop="purchaseAmount" label="数量" />
+                                    <el-table-column prop="remark" label="开发部备注" />
+                                </el-table>
+                            </div>
+                        </el-col>
+                    </el-row>
+                </el-tab-pane>
+            </el-tabs>
+
+            <template #footer>
+                <span>
+                    <el-button @click="purchaseOrderCreateVis = false">取消</el-button>
+                    <el-button type="primary" @click="confirmPurchaseDivideOrderSave">保存</el-button>
+                    <el-button type="success" @click="confirmPurchaseDivideOrderSubmit">提交</el-button>
+                </span>
+            </template>
+        </el-dialog>
     </el-container>
 </template>
 
@@ -102,23 +126,40 @@
 import axios from 'axios'
 import PurchaseItemsTable from '@/Pages/LogisticsControlDepartment/LogisticsControlManager/components/VariousPurchaseTables/PurchaseItemsTable.vue';
 import { ElMessage } from 'element-plus';
+import { getShoeSizesName } from '@/Pages/utils/getShoeSizesName'
 export default {
+    props: ['orderid'],
     components: {
         PurchaseItemsTable
     },
     data() {
         return {
+            getShoeSizesName,
+            purchaseOrderCreateVis: false,
+            activeTab: '',
+            tabPlaneData: [],
+            isPackageSearchDialogVisable: false,
+            isSizeComparisonDialogVisible: false,
             orderSearch: '',
             customerSearch: '',
+            currentOrderRid: '',
+            packageNameSearch: '',
+            filteredMaterialList: [],
             orderList: [],
             filteredList: [],
             currentPage: 1,
             pageSize: 10,
-            orderPackagingStatus: '0',
+            currentPackageType: '',
+            orderPackageStatus: '0',
             materialTypeOptions: [],
             currentEditPurchaseOrderRid: '',
             currentEditPurchaseOrderId: 0,
             createEditSymbol: 0,
+            currentShoeSizeType: '',
+            currentOrderDBId: 0,
+            sizeGridOptions: [],
+            shoeSizeColumns: [],
+            sizeLabelColumns: [],
             assetForm: {
                 purchaseOrderType: 'P',
                 orderId: null,
@@ -149,7 +190,9 @@ export default {
                                 callback(new Error("尚未选择订单鞋型"));
                             } else {
                                 callback();
+
                             }
+
                         },
                         trigger: "change",
                     },
@@ -164,10 +207,58 @@ export default {
         }
     },
     mounted() {
-        this.getAllOrders();
+        this.getOrderInfo(this.orderid);
         this.getAllMaterialTypes();
+        this.getCurrentPurchaseOrder();
+        this.getBatchTypeList();
+
     },
     methods: {
+        async getCurrentPurchaseOrder() {
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/getpackagepurchaseorderitems`, {
+                params: {
+                    orderid: this.orderid
+                }
+            });
+            this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid || '';
+            this.currentEditPurchaseOrderId = response.data.purchaseOrderId || null;
+            this.assetForm.purchaseData = response.data.purchaseOrderItems;
+            this.assetForm.orderId = this.orderid;
+            this.assetForm.purchaseOrderType = 'P';
+            if (this.currentEditPurchaseOrderId === null) {
+                {
+                    this.createPackagePurchaseOrder(this.orderid)
+                }
+            }
+            else {
+                this.createEditSymbol = 1
+            }
+        },
+        async openSubmitDialog() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/logistics/getindividualpurchaseorders`,
+                {
+                    params: {
+                        purchaseOrderId: this.currentEditPurchaseOrderId
+                    }
+                }
+            )
+            this.tabPlaneData = response.data
+            console.log(this.tabPlaneData)
+            if (this.tabPlaneData.length > 0) {
+                this.activeTab = this.tabPlaneData[0].purchaseDivideOrderId
+            }
+            this.purchaseOrderCreateVis = true
+        },
+        async getOrderInfo(orderId) {
+            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo`, {
+                params: {
+                    orderid: orderId
+                }
+            });
+            this.currentOrderRid = response.data.orderId;
+            this.currentOrderDBId = response.data.orderDBId;
+        },
         async getAllOrders() {
             try {
                 const response = await axios.get(`${this.$apiBaseUrl}/order/getallorders`);
@@ -182,8 +273,57 @@ export default {
             console.log(response.data);
             this.materialTypeOptions = response.data.filter(materialType => materialType.materialTypeName === '包材');
         },
+        async searchPackage() {
+            this.filteredMaterialList = [];
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/searchpackagematerialinfo`, {
+                params: {
+                    materialModel: this.packageNameSearch
+                }
+            });
+            this.filteredMaterialList = response.data.data;
+        },
+        async openPackageSearchDialog() {
+            this.shoeSizeColumns = await this.getShoeSizesName(this.assetForm.orderId)
+            this.currentShoeSizeType = this.shoeSizeColumns[0].type
+            this.isPackageSearchDialogVisable = true;
+            this.packageNameSearch = this.currentPackageType;
+            this.packageNameSearch = this.packageNameSearch.replace(/[^a-zA-Z0-9]/g, '');
+            this.filteredMaterialList = [];
+            const response = await axios.get(`${this.$apiBaseUrl}/logistics/searchpackagematerialinfo`, {
+                params: {
+                    materialModel: this.packageNameSearch
+                }
+            });
+            this.filteredMaterialList = response.data.data;
+
+        },
+        async getSizeTableData() {
+            const response = await axios.get(
+                `${this.$apiBaseUrl}/devproductionorder/getsizetable?orderId=${this.currentOrderDBId}`
+            )
+
+            this.sizeGridOptions = response.data
+            console.log(this.sizeGridOptions)
+        },
+        filteredColumns(array) {
+            if (!array || !this.sizeLabelColumns) return [];
+
+            return Object.keys(this.sizeLabelColumns)
+                .map((slotKey) => {
+                    const amountKey = slotKey.replace("Slot", "Amount"); // Convert size34Slot → size34Amount
+
+                    if (array.some(row => row[amountKey] !== undefined && row[amountKey] !== 0)) {
+                        return {
+                            prop: amountKey,
+                            label: this.sizeLabelColumns[slotKey] // Use size number (e.g., "34", "35")
+                        };
+                    }
+                    return null;
+                })
+                .filter(column => column !== null); // Remove null values
+        },
         packageStatusFormatter(row) {
-            switch (row.orderPackagingStatus) {
+            switch (row.orderPackageStatus) {
                 case '0':
                     return '未采购';
                 case '1':
@@ -192,88 +332,40 @@ export default {
                     return '已采购';
             }
         },
-        viewPackagingInfo(row) {
-            window.open(`${this.$apiBaseUrl}/orderimport/downloadorderdoc?orderrid=${row.orderRid}&filetype=2`);
-        },
-        async createPackagePurchaseOrder(row) {
-            if (this.currentEditPurchaseOrderRid != '') {
-                this.$confirm('当前有未保存的采购订单，是否放弃编辑?', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(async () => {
-                    this.currentEditPurchaseOrderRid = '';
-                    const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewpackagepurchaseorderid`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                    this.createEditSymbol = 0;
-                    this.assetForm.purchaseData = [];
-                    this.assetForm.orderId = row.orderDbId;
-                    this.assetForm.purchaseOrderType = 'P';
-                    console.log(this.currentEditPurchaseOrderRid);
-                    return
-                }).catch(() => {
-                    return;
+        async createPackagePurchaseOrder(orderid) {
+            console.log(this.currentEditPurchaseOrderRid);
+            if (this.currentEditPurchaseOrderRid !== '') {
+                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getpackagepurchaseorderitems`, {
+                    params: {
+                        orderid: orderid
+                    }
                 });
+                this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
+                this.currentEditPurchaseOrderId = response.data.purchaseOrderId;
+                console.log(response.data.purchaseOrderItems)
+                this.assetForm.purchaseData = response.data.purchaseOrderItems;
+                this.assetForm.orderId = orderid;
+                this.assetForm.purchaseOrderType = 'P';
+                console.log(this.assetForm)
+                console.log(this.currentEditPurchaseOrderRid);
             }
             else {
                 const response = await axios.get(`${this.$apiBaseUrl}/logistics/getnewpackagepurchaseorderid`, {
                     params: {
-                        orderid: row.orderDbId
+                        orderid: orderid
                     }
                 });
                 this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
                 this.createEditSymbol = 0;
                 this.assetForm.purchaseData = [];
-                this.assetForm.orderId = row.orderDbId;
-                this.assetForm.purchaseOrderType = 'P';
-                console.log(this.currentEditPurchaseOrderRid);
-            }
-        },
-        async editPackagePurchaseOrder(row) {
-            if (this.currentEditPurchaseOrderRid != '') {
-                this.$confirm('当前有未保存的采购订单，是否放弃编辑?', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(async () => {
-                    this.currentEditPurchaseOrderRid = '';
-                    const response = await axios.get(`${this.$apiBaseUrl}/logistics/getpackagepurchaseorderitems`, {
-                        params: {
-                            orderid: row.orderDbId
-                        }
-                    });
-                    this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                    this.createEditSymbol = 1;
-                    this.assetForm.purchaseData = response.data.purchaseOrderItems;
-                    this.assetForm.orderId = row.orderDbId;
-                    this.assetForm.purchaseOrderType = 'P';
-                    console.log(this.currentEditPurchaseOrderRid);
-                    return
-                }).catch(() => {
-                    return;
-                });
-            }
-            else {
-                this.createEditSymbol = 1;
-                const response = await axios.get(`${this.$apiBaseUrl}/logistics/getpackagepurchaseorderitems`, {
-                    params: {
-                        orderid: row.orderDbId
-                    }
-                });
-                this.currentEditPurchaseOrderRid = response.data.purchaseOrderRid;
-                this.assetForm.purchaseData = response.data.purchaseOrderItems;
-                this.assetForm.orderId = row.orderDbId;
+                this.assetForm.orderId = orderid;
                 this.assetForm.purchaseOrderType = 'P';
                 console.log(this.currentEditPurchaseOrderRid);
             }
         },
         updateNewPurchaseData(updatedItems) {
-            this.assetForm.purchaseData = [...updatedItems]
-
+            this.assetForm.purchaseData = [...updatedItems]; // Ensures Vue detects the change
+            console.log("Updated purchaseData:", this.assetForm.purchaseData);
         },
         savePackagePurchaseOrder() {
             this.$refs.purchaseForm.validate(async (valid) => {
@@ -304,7 +396,7 @@ export default {
                                     purchaseOrderRId: this.currentEditPurchaseOrderRid,
                                     orderId: this.assetForm.orderId,
                                     orderShoeId: this.assetForm.orderShoeId,
-                                    batchInfoType : this.assetForm.batchInfoType,
+                                    batchInfoType: this.assetForm.batchInfoType,
                                     purchaseOrderType: this.assetForm.purchaseOrderType
                                 }
                             )
@@ -317,7 +409,7 @@ export default {
                                     purchaseOrderRId: this.currentEditPurchaseOrderRid,
                                     orderId: this.assetForm.orderId,
                                     orderShoeId: this.assetForm.orderShoeId,
-                                    batchInfoType : this.assetForm.batchInfoType,
+                                    batchInfoType: this.assetForm.batchInfoType,
                                     purchaseOrderType: this.assetForm.purchaseOrderType
                                 }
                             )
@@ -325,7 +417,7 @@ export default {
                         ElMessage.success('保存成功')
 
                         // Close the current page
-                        }
+                    }
                     catch (error) {
                         console.log(error)
                         ElMessage.error("保存失败")
@@ -334,16 +426,101 @@ export default {
                 else {
                     console.log("validation error")
                 }
+                this.getCurrentPurchaseOrder();
             })
         },
-
+        confirmPurchaseDivideOrderSave() {
+            this.$confirm('确定保存此分采购订单吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.submitPurchaseDivideOrderSave()
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消保存'
+                    })
+                })
+        },
+        confirmPurchaseDivideOrderSubmit() {
+            this.$confirm('确定提交此分采购订单吗？', '提示', {
+                confirmButtonText: '确定',
+                cancelButtonText: '取消',
+                type: 'warning'
+            })
+                .then(() => {
+                    this.submitPurchaseDivideOrder()
+                })
+                .catch(() => {
+                    this.$message({
+                        type: 'info',
+                        message: '已取消提交'
+                    })
+                })
+        },
+        async submitPurchaseDivideOrderSave() {
+            const loadingInstance = this.$loading({
+                lock: true,
+                text: '等待中，请稍后...',
+                background: 'rgba(0, 0, 0, 0.7)'
+            })
+            const response = await this.$axios.post(
+                `${this.$apiBaseUrl}/firstpurchase/savepurchasedivideorders`,
+                {
+                    purchaseOrderId: this.currentEditPurchaseOrderId,
+                    purchaseDivideOrders: this.tabPlaneData
+                }
+            )
+            loadingInstance.close()
+            if (response.status !== 200) {
+                this.$message({
+                    type: 'error',
+                    message: '保存失败'
+                })
+                return
+            }
+            this.$message({
+                type: 'success',
+                message: '保存成功'
+            })
+            this.purchaseOrderCreateVis = false
+        },
+        async submitPurchaseDivideOrder() {
+            const loadingInstance = this.$loading({
+                lock: true,
+                text: '等待中，请稍后...',
+                background: 'rgba(0, 0, 0, 0.7)'
+            })
+            const response = await this.$axios.post(
+                `${this.$apiBaseUrl}/logistics/submitindividualpurchaseorders`,
+                {
+                    purchaseOrderId: this.currentEditPurchaseOrderId
+                }
+            )
+            loadingInstance.close()
+            if (response.status !== 200) {
+                this.$message({
+                    type: 'error',
+                    message: '提交失败'
+                })
+                return
+            }
+            this.$message({
+                type: 'success',
+                message: '提交成功'
+            })
+            this.purchaseOrderCreateVis = false
+        },
         handleFilter() {
             this.currentPage = 1;
             this.filteredList = this.orderList.filter(order => {
                 return (
                     (!this.orderSearch || order.orderRid.includes(this.orderSearch)) &&
                     (!this.customerSearch || order.customerName.includes(this.customerSearch)) &&
-                    (order.orderPackagingStatus === this.orderPackagingStatus)
+                    (order.orderPackageStatus === this.orderPackageStatus)
                 );
             });
         },
@@ -353,7 +530,27 @@ export default {
         },
         handleCurrentChange(newPage) {
             this.currentPage = newPage;
-        }
+        },
+        jumpOverPackagePurchase() {
+        },
+        factoryFieldJudge(field) {
+            if (field === 'N') {
+                return false
+            }
+            return true
+        },
+        async getBatchTypeList() {
+            const response = await axios.get(`${this.$apiBaseUrl}/shoe/getshoebatchinfotypebysizetable`, {
+                params: {
+                    orderId: this.orderid
+                }
+            })
+            console.log(response.data)
+            this.sizeLabelColumns = response.data
+        },
+        viewPackagingInfo() {
+            window.open(`${this.$apiBaseUrl}/orderimport/downloadorderdoc?orderrid=${this.currentOrderRid}&filetype=2`);
+        },
     }
 }
 </script>


### PR DESCRIPTION
针对之前提出的问题进行了调整
1.一次采购订单现在按照面，里，大，中，烫顺序排序，分采购订单也按此顺序排列
2.缩小了表格范围保持按钮可视
3.可以使用回车在数量输入框见切换
4.重新调整了尺码数量显示规格
5.挪动楦头，包材，刀模采购至一次采购页面，删除批量下发以及独立采购页面
6.重新编写楦，包，刀的采购逻辑，在同页面下发，节省操作

目前问题
刀模页面未定，暂未完成