### PR TITLE
多选材料入库时，库存材料的规格和型号默认为第一个选中的材料

### DIFF
--- a/backend-python/warehouse/material_storage.py
+++ b/backend-python/warehouse/material_storage.py
@@ -1807,6 +1807,7 @@ def get_inbound_record_by_batch_id():
                 Material,
                 Supplier,
                 Order,
+                Shoe
             )
             .join(
                 InboundRecord,
@@ -1826,6 +1827,14 @@ def get_inbound_record_by_batch_id():
             .outerjoin(
                 Order,
                 Order.order_id == MaterialStorage.order_id,
+            )
+            .outerjoin(
+                OrderShoe,
+                OrderShoe.order_id == MaterialStorage.order_id,
+            )
+            .outerjoin(
+                Shoe,
+                Shoe.shoe_id == OrderShoe.shoe_id,
             )
             .filter(
                 InboundRecord.inbound_batch_id == inbound_batch_id,
@@ -1883,6 +1892,7 @@ def get_inbound_record_by_batch_id():
             material,
             supplier,
             order,
+            shoe
         ) = row
         unit_price = (
             round(record_detail.unit_price, 3) if record_detail.unit_price else 0.00
@@ -1914,6 +1924,7 @@ def get_inbound_record_by_batch_id():
             "orderRId": order.order_rid if order else None,
             "supplierName": supplier.supplier_name if supplier else None,
             "shoeSizeColumns": shoe_size_columns,
+            "shoeRId": shoe.shoe_rid if shoe else None,
         }
         for i in range(len(SHOESIZERANGE)):
             shoe_size = SHOESIZERANGE[i]

--- a/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/MaterialSelectDialog.vue
+++ b/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/MaterialSelectDialog.vue
@@ -303,12 +303,12 @@ export default {
                     orderRId: null,
                     shoeRId: null,
                     inboundQuantity: remainTotalQuantity,
-                    ...this.materialSelection,
+                    ...this.materialSelection[0],
                     disableEdit: true,
                     unitPrice: this.unitPrice,
                     itemTotalPrice: (remainTotalQuantity * this.unitPrice).toFixed(3),
-                    inboundModel: this.materialSelection.materialModel,
-                    inboundSpecification: this.materialSelection.materialSpecification,
+                    inboundModel: this.materialSelection[0].materialModel,
+                    inboundSpecification: this.materialSelection[0].materialSpecification,
                 })
             }
             this.$emit("confirm", this.topTableData);

--- a/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseInbound.vue
+++ b/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseInbound.vue
@@ -62,7 +62,7 @@
                 </vxe-column>
                 <vxe-column field="shoeRId" title="工厂鞋型" :edit-render="{ autoFocus: 'input' }" width="150">
                     <template #edit="scope">
-                        <vxe-input v-model="scope.row.shoeRId" clearable :disabled="scope.row.disableEdit"
+                        <vxe-input v-model="scope.row.shoeRId" clearable :disabled="true"
                             @keydown="(event) => handleKeydown(event, scope)"></vxe-input>
                     </template>
                 </vxe-column>


### PR DESCRIPTION
解决多余材料无法按库存入库