### PR TITLE
修改面里料自动分配页面

### DIFF
--- a/backend-python/warehouse/material_storage.py
+++ b/backend-python/warehouse/material_storage.py
@@ -354,7 +354,8 @@ def get_size_materials():
             "estimatedInboundAmount": storage.total_estimated_inbound_amount,
             "actualInboundAmount": storage.total_actual_inbound_amount,
             "currentAmount": storage.total_current_amount,
-            "remainingAmount": storage.total_estimated_inbound_amount - storage.total_actual_inbound_amount,
+            "remainingAmount": storage.total_estimated_inbound_amount
+            - storage.total_actual_inbound_amount,
             "unitPrice": storage.unit_price,
             "shoeSizeColumns": storage.shoe_size_columns,
             "inboundModel": storage.size_material_model,
@@ -371,20 +372,25 @@ def get_size_materials():
             obj[f"estimatedInboundAmount{i}"] = estimated_inbound_amount
             obj[f"actualInboundAmount{i}"] = actual_inbound_amount
             obj[f"currentAmount{i}"] = current_amount
-            obj[f"remainingAmount{i}"] = estimated_inbound_amount - actual_inbound_amount
+            obj[f"remainingAmount{i}"] = (
+                estimated_inbound_amount - actual_inbound_amount
+            )
         result.append(obj)
     return result
 
 
 @material_storage_bp.route("/warehouse/getmaterials", methods=["GET"])
 def get_materials():
+    page = request.args.get("page", type=int, default=1)
+    page_size = request.args.get("pageSize", type=int, default=10)
+    show_unfinished_orders = request.args.get("showUnfinishedOrders")
     filters = {
         "material_name": request.args.get("materialName", ""),
         "material_spec": request.args.get("materialSpec", ""),
         "material_model": request.args.get("materialModel", ""),
         "material_color": request.args.get("materialColor", ""),
         "supplier": request.args.get("supplier", ""),
-        # "order_rid": request.args.get("orderRId", ""),
+        "order_rid": request.args.get("orderRId", ""),
     }
     material_filter_map = {
         "material_name": Material.material_name,
@@ -392,216 +398,67 @@ def get_materials():
         "material_model": MaterialStorage.material_model,
         "material_color": MaterialStorage.material_storage_color,
         "supplier": Supplier.supplier_name,
-        # "order_rid": Order.order_rid,
+        "order_rid": Order.order_rid,
     }
     query = (
         db.session.query(
-            MaterialStorage.material_model,
-            MaterialStorage.material_specification,
-            MaterialStorage.material_storage_color,
-            MaterialStorage.actual_inbound_unit,
+            MaterialStorage,
             Material.material_name,
             Material.material_category,
             Supplier.supplier_name,
+            Order.order_rid,
+            Shoe.shoe_rid,
         )
         .join(
             Material,
             MaterialStorage.actual_inbound_material_id == Material.material_id,
         )
         .join(Supplier, Material.material_supplier == Supplier.supplier_id)
-        .distinct()
+        .join(Order, Order.order_id == MaterialStorage.order_id)
+        .join(OrderShoe, Order.order_id == OrderShoe.order_id)
+        .join(Shoe, OrderShoe.shoe_id == Shoe.shoe_id)
     )
     for key, value in filters.items():
         if value and value != "":
             query = query.filter(material_filter_map[key].ilike(f"%{value}%"))
-    response = query.all()
+    if show_unfinished_orders == "true":
+        query = query.filter(
+            MaterialStorage.estimated_inbound_amount
+            - MaterialStorage.actual_inbound_amount
+            > 0
+        )
+    count_result = query.distinct().count()
+    response = query.distinct().limit(page_size).offset((page - 1) * page_size).all()
     result = []
     for row in response:
         (
-            material_model,
-            material_specification,
-            color,
-            unit,
+            storage,
             material_name,
             material_category,
             supplier_name,
+            order_rid,
+            shoe_rid,
         ) = row
         obj = {
+            "orderRId": order_rid,
+            "shoeRId": shoe_rid,
             "materialName": material_name,
-            "materialModel": material_model,
-            "materialSpecification": material_specification,
-            "materialColor": color,
-            "actualInboundUnit": unit,
+            "materialModel": storage.material_model,
+            "materialSpecification": storage.material_specification,
+            "materialColor": storage.material_storage_color,
+            "actualInboundUnit": storage.actual_inbound_unit,
+            "inboundModel": storage.material_model,
+            "inboundSpecification": storage.material_specification,
             "materialCategory": material_category,
             "supplierName": supplier_name,
+            "estimatedInboundAmount": storage.estimated_inbound_amount,
+            "actualInboundAmount": storage.actual_inbound_amount,
+            "currentAmount": storage.current_amount,
+            "remainingAmount": storage.estimated_inbound_amount
+            - storage.actual_inbound_amount,
         }
         result.append(obj)
-    return result
-
-@material_storage_bp.route("/warehouse/getordersbysizematerialinfo", methods=["GET"])
-def get_orders_by_size_material_info():
-    """
-    根据材料信息查找买这个材料的订单号
-    """
-    data = request.args.get("data", None)
-    data_list = json.loads(data)
-    result = []
-    for input_row in data_list:
-        material_name = input_row.get("materialName", None)
-        material_specification = input_row.get("materialSpecification", None)
-        material_model = input_row.get("materialModel", None)
-        material_color = input_row.get("materialColor", None)
-        supplier_name = input_row.get("supplierName", None)
-        material_category = input_row.get("materialCategory", 0)
-        unit = input_row.get("actualInboundUnit", None)
-
-        target_material = (
-            db.session.query(Material)
-            .join(Supplier, Material.material_supplier == Supplier.supplier_id)
-            .filter(
-                Material.material_name == material_name,
-                Supplier.supplier_name == supplier_name,
-            )
-            .first()
-        )
-
-        if not target_material:
-            return jsonify({"message": "没有该材料"}), 404
-
-        material_storages = (
-            db.session.query(SizeMaterialStorage, Order, Shoe)
-            .outerjoin(Order, Order.order_id == SizeMaterialStorage.order_id)
-            .outerjoin(
-                OrderShoe, OrderShoe.order_shoe_id == SizeMaterialStorage.order_shoe_id
-            )
-            .outerjoin(Shoe, OrderShoe.shoe_id == Shoe.shoe_id)
-            .outerjoin(OrderStatus, OrderStatus.order_id == Order.order_id)
-            .filter(
-                SizeMaterialStorage.material_id
-                == target_material.material_id,
-                SizeMaterialStorage.size_material_specification == material_specification,
-                SizeMaterialStorage.size_material_model == material_model,
-                SizeMaterialStorage.size_material_color == material_color,
-                or_(
-                    OrderStatus.order_current_status == IN_PRODUCTION_ORDER_NUMBER,
-                    OrderStatus.order_current_status == None,
-                ),
-            )
-            .order_by(
-                Order.order_rid
-            )
-            .all()
-        )
-        for row in material_storages:
-            storage, order, shoe = row
-            obj = {
-                "materialStorageId": storage.size_material_storage_id,
-                "materialName": target_material.material_name,
-                "materialModel": storage.size_material_model,
-                "materialSpecification": storage.size_material_specification,
-                "materialColor": storage.size_material_color,
-                "actualInboundUnit": target_material.material_unit,
-                "inboundModel": storage.size_material_model,
-                "inboundSpecification": storage.size_material_specification,
-                "orderId": storage.order_id,
-                "orderRId": order.order_rid if order else None,
-                "shoeRId": shoe.shoe_rid if shoe else None,
-                "estimatedInboundAmount": storage.total_estimated_inbound_amount,
-                "actualInboundAmount": storage.total_actual_inbound_amount,
-                "currentAmount": storage.total_current_amount,
-                "materialCategory": material_category,
-                "shoeSizeColumns": storage.shoe_size_columns,
-                "remainingAmount": storage.total_estimated_inbound_amount - storage.total_actual_inbound_amount,
-            }
-            for i, shoe_size in enumerate(SHOESIZERANGE):
-                estimated_inbound_amount = getattr(
-                    storage, f"size_{shoe_size}_estimated_inbound_amount"
-                )
-                actual_inbound_amount = getattr(
-                    storage, f"size_{shoe_size}_actual_inbound_amount"
-                )
-                current_amount = getattr(storage, f"size_{shoe_size}_current_amount")
-                obj[f"estimatedInboundAmount{i}"] = estimated_inbound_amount
-                obj[f"actualInboundAmount{i}"] = actual_inbound_amount
-                obj[f"currentAmount{i}"] = current_amount
-                obj[f"remainingAmount{i}"] = estimated_inbound_amount - actual_inbound_amount
-            result.append(obj)
-    return result
-
-@material_storage_bp.route("/warehouse/getordersbymaterialinfo", methods=["GET"])
-def get_orders_by_material_info():
-    """
-    根据材料信息查找买这个材料的订单号
-    """
-    data = request.args.get("data", None)
-    data_list = json.loads(data)
-    result = []
-    for input_row in data_list:
-        material_name = input_row.get("materialName", None)
-        material_specification = input_row.get("materialSpecification", None)
-        material_model = input_row.get("materialModel", None)
-        material_color = input_row.get("materialColor", None)
-        supplier_name = input_row.get("supplierName", None)
-        material_category = input_row.get("materialCategory", 0)
-        unit = input_row.get("actualInboundUnit", None)
-
-        target_material = (
-            db.session.query(Material)
-            .join(Supplier, Material.material_supplier == Supplier.supplier_id)
-            .filter(
-                Material.material_name == material_name,
-                Supplier.supplier_name == supplier_name,
-            )
-            .first()
-        )
-
-        if not target_material:
-            return jsonify({"message": "没有该材料"}), 404
-
-        material_storages = (
-            db.session.query(MaterialStorage, Order, Shoe)
-            .outerjoin(Order, Order.order_id == MaterialStorage.order_id)
-            .outerjoin(
-                OrderShoe, OrderShoe.order_shoe_id == MaterialStorage.order_shoe_id
-            )
-            .outerjoin(Shoe, OrderShoe.shoe_id == Shoe.shoe_id)
-            .outerjoin(OrderStatus, OrderStatus.order_id == Order.order_id)
-            .filter(
-                MaterialStorage.actual_inbound_material_id
-                == target_material.material_id,
-                MaterialStorage.material_specification == material_specification,
-                MaterialStorage.material_model == material_model,
-                MaterialStorage.material_storage_color == material_color,
-                MaterialStorage.actual_inbound_unit == unit,
-                or_(
-                    OrderStatus.order_current_status == IN_PRODUCTION_ORDER_NUMBER,
-                    OrderStatus.order_current_status == None,
-                ),
-            )
-            .all()
-        )
-        for row in material_storages:
-            storage, order, shoe = row
-            obj = {
-                "materialStorageId": storage.material_storage_id,
-                "materialName": target_material.material_name,
-                "materialModel": storage.material_model,
-                "materialSpecification": storage.material_specification,
-                "materialColor": storage.material_storage_color,
-                "actualInboundUnit": storage.actual_inbound_unit,
-                "inboundModel": storage.inbound_model,
-                "inboundSpecification": storage.inbound_specification,
-                "orderId": storage.order_id,
-                "orderRId": order.order_rid if order else None,
-                "shoeRId": shoe.shoe_rid if shoe else None,
-                "estimatedInboundAmount": storage.estimated_inbound_amount,
-                "actualInboundAmount": storage.actual_inbound_amount,
-                "currentAmount": storage.current_amount,
-                "remainingAmount": storage.estimated_inbound_amount - storage.actual_inbound_amount,
-                "materialCategory": material_category,
-            }
-            result.append(obj)
-    return result
+    return {"result": result, "total": count_result}
 
 
 @material_storage_bp.route(
@@ -1453,8 +1310,7 @@ def get_inbound_record_by_id():
             )
             .join(
                 MaterialWarehouse,
-                MaterialWarehouse.material_warehouse_id
-                == InboundRecord.warehouse_id,
+                MaterialWarehouse.material_warehouse_id == InboundRecord.warehouse_id,
             )
             .outerjoin(Supplier, Supplier.supplier_id == InboundRecord.supplier_id)
             .outerjoin(
@@ -1512,8 +1368,7 @@ def get_inbound_record_by_id():
             )
             .join(
                 MaterialWarehouse,
-                MaterialWarehouse.material_warehouse_id
-                == InboundRecord.warehouse_id,
+                MaterialWarehouse.material_warehouse_id == InboundRecord.warehouse_id,
             )
             .outerjoin(Supplier, Supplier.supplier_id == InboundRecord.supplier_id)
             .outerjoin(
@@ -2309,7 +2164,6 @@ def delete_inbound_record():
     return jsonify({"message": "success"})
 
 
-
 @material_storage_bp.route("/warehouse/getallmaterialmodels", methods=["GET"])
 def get_all_material_models():
     material_model = request.args.get("materialModel")
@@ -2325,9 +2179,6 @@ def get_all_material_models():
     )
     result = []
     for model in material_models:
-        obj = {
-            "value": model[0],
-            "name": model[0]
-        }
+        obj = {"value": model[0], "name": model[0]}
         result.append(obj)
     return jsonify(result)

--- a/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseInbound.vue
+++ b/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseInbound.vue
@@ -161,7 +161,7 @@
         </el-col>
     </el-row>
 
-    <MaterialSelectDialog :visible="isMaterialSelectDialogVis" :searchedMaterials="searchedMaterials"
+    <MaterialSelectDialog v-if="showMaterialSelectDialog" :visible="isMaterialSelectDialogVis" :searchParams="searchParams"
         @confirm="updateMaterialTableData" @update-visible="updateDialogVisible" />
 
     <SizeMaterialSelectDialog :visible="isSizeMaterialSelectDialogVis" :searched-size-materials="searchedSizeMaterials"
@@ -402,7 +402,16 @@ export default {
                         row.inboundModel = selected;
                     }
                 }
-            }
+            },
+            searchParams: {
+                orderId: null,
+                materialName: null,
+                materialSpec: null,
+                materialModel: null,
+                materialColor: null,
+                supplier: null
+            },
+            showMaterialSelectDialog: false,
         }
     },
     // beforeUnmount() {
@@ -613,6 +622,7 @@ export default {
             this.shoeSizeColumns = sizeColumns
         },
         updateDialogVisible(value) {
+            this.showMaterialSelectDialog = value
             this.isMaterialSelectDialogVis = value
         },
         updateSizeMaterialDialogVisible(value) {
@@ -754,23 +764,20 @@ export default {
             }
             else {
                 this.fetchMaterialData()
+                this.showMaterialSelectDialog = true
                 this.isMaterialSelectDialogVis = true
             }
         },
         async fetchMaterialData() {
             const params = {
+                "orderRId": this.currentKeyDownRow.orderRId,
                 "materialName": this.currentKeyDownRow.materialName,
                 "materialSpec": this.currentKeyDownRow.inboundSpecification,
                 "materialModel": this.currentKeyDownRow.inboundModel,
                 "materialColor": this.currentKeyDownRow.materialColor,
                 "supplier": this.inboundForm.supplierName,
             }
-            const response = await axios.get(`${this.$apiBaseUrl}/warehouse/getmaterials`, { params })
-            this.searchedMaterials = response.data
-            // add unique id to each row
-            this.searchedMaterials.forEach(item => {
-                item.id = XEUtils.uniqueId()
-            })
+            this.searchParams = params; // Update search parameters
         },
         async fetchSizeMaterialData() {
             const params = {


### PR DESCRIPTION
1. 鉴于账单现有订单号，自动分配第一页添加订单号/供应商/材料四项的信息和搜索
2. 第二页根据用户选择了的订单再自动分配

示例：
1. 输入材料信息
![image](https://github.com/user-attachments/assets/8f072633-9d7c-4f24-a5a4-00795e9120d5)

2. 选择订单号
![image](https://github.com/user-attachments/assets/ec62ef0b-0e2d-49f8-af94-718f9482ad1c)

3. 输入总数点自动分配
![image](https://github.com/user-attachments/assets/68b37592-0547-457b-9790-c3ee25c5a8f5)

4. 结果
![image](https://github.com/user-attachments/assets/b393b250-52ee-4758-82ee-957ecdc9d3f7)

