### PR TITLE
db material storage merge change

### DIFF
--- a/backend-python/accounting/accounting_warehouse.py
+++ b/backend-python/accounting/accounting_warehouse.py
@@ -24,7 +24,7 @@ INBOUND_SUMMARY_MATERIAL_COLUMNS = ["material_name","material_unit"]
 
 INBOUND_RECORD_SELECTABLE_TABLE_ATTRNAMES = ["inbound_rid", "inbound_datetime","approval_status"]
 INBOUND_RECORD_DETAIL_SELECTABLE_TABLE_ATTRNAMES = ["unit_price", "inbound_amount","item_total_price","composite_unit_cost","remark"]
-MATERIAL_SELECTABLE_TABLE_ATTRNAMES = ["material_name","material_unit"]
+MATERIAL_SELECTABLE_TABLE_ATTRNAMES = ["material_name"]
 
 SPU_MATERIAL_TABLE_ATTRNAMES = ['material_model','material_specification','color','spu_rid']
 
@@ -44,7 +44,7 @@ name_en_cn_mapping_inbound = {
     "material_specification":"材料规格",
     "order_rid":"订单号",
     "unit_price":"采购单价",
-    "material_unit":"单位",
+    "actual_inbound_unit":"单位",
     "inbound_amount":"入库数量",
     "item_total_price":"总价",
     "approval_status":"审批状态",
@@ -99,6 +99,8 @@ def get_warehouse_info():
         res_data.append(db_obj_to_res(entity, MaterialWarehouse, len('material_')))
     return jsonify({"warehouseInfo":res_data}), 200
 
+old_ms_new_ms_mapping = {}
+size_ms_mapping = {}
 def wrapper_helper():
     ### inboundrecord inbound_rid, inbound_date_time, supplier
     ### inboundrecorddetail unit_price, item_total_price, inbound_amount
@@ -107,62 +109,62 @@ def wrapper_helper():
     # material.material_name, material_unit
     #  
     return
-@accounting_warehouse_bp.route("/accounting/get_warehouse_outbound_record", methods=["GET"])
-def get_warehouse_outbound_record():
-    page_num = request.args.get('pageNumber',type=int)
-    page_size = request.args.get('pageSize', type=int)
-    warehouse_filter = request.args.get('selectedWarehouse')
-    supplier_name_filter = request.args.get('supplierNameFilter', type=str)
-    date_range_filter_start = request.args.get('dateRangeFilterStart', type=str)
-    date_range_filter_end = request.args.get('dateRangeFilterEnd', type=str)
-    material_model_filter = request.args.get('materialModelFilter', type=str)
-    outbound_type_filter = request.args.get('outboudnTypeFilter', type=str)
-    query = (db.session.query(OutboundRecord, OutboundRecordDetail, Material, Supplier, MaterialType, MaterialWarehouse, SPUMaterial, MaterialStorage.average_price)
-             .join(OutboundRecordDetail, OutboundRecord.outbound_record_id == OutboundRecordDetail.outbound_record_id)
-             .join(MaterialStorage, OutboundRecordDetail.material_storage_id == MaterialStorage.material_storage_id)
-             .join(SPUMaterial, MaterialStorage.spu_material_id == SPUMaterial.spu_material_id)
-             .join(Material, MaterialStorage.material_id == Material.material_id)
-             .join(Supplier, Material.material_supplier == Supplier.supplier_id)
-             .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
-             .join(MaterialWarehouse, MaterialType.warehouse_id == MaterialWarehouse.material_warehouse_id))
+# @accounting_warehouse_bp.route("/accounting/get_warehouse_outbound_record", methods=["GET"])
+# def get_warehouse_outbound_record():
+#     page_num = request.args.get('pageNumber',type=int)
+#     page_size = request.args.get('pageSize', type=int)
+#     warehouse_filter = request.args.get('selectedWarehouse')
+#     supplier_name_filter = request.args.get('supplierNameFilter', type=str)
+#     date_range_filter_start = request.args.get('dateRangeFilterStart', type=str)
+#     date_range_filter_end = request.args.get('dateRangeFilterEnd', type=str)
+#     material_model_filter = request.args.get('materialModelFilter', type=str)
+#     outbound_type_filter = request.args.get('outboudnTypeFilter', type=str)
+#     query = (db.session.query(OutboundRecord, OutboundRecordDetail, Material, Supplier, MaterialType, MaterialWarehouse, SPUMaterial, MaterialStorage.average_price)
+#              .join(OutboundRecordDetail, OutboundRecord.outbound_record_id == OutboundRecordDetail.outbound_record_id)
+#              .join(MaterialStorage, OutboundRecordDetail.material_storage_id == MaterialStorage.material_storage_id)
+#              .join(SPUMaterial, MaterialStorage.spu_material_id == SPUMaterial.spu_material_id)
+#              .join(Material, MaterialStorage.material_id == Material.material_id)
+#              .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+#              .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+#              .join(MaterialWarehouse, MaterialType.warehouse_id == MaterialWarehouse.material_warehouse_id))
     
-    sized_query = (db.session.query(OutboundRecord, OutboundRecordDetail, Material, Supplier, MaterialType, MaterialWarehouse, SPUMaterial, SizeMaterialStorage.average_price)
-             .join(OutboundRecordDetail, OutboundRecord.outbound_record_id == OutboundRecordDetail.outbound_record_id)
-             .join(SizeMaterialStorage, OutboundRecordDetail.size_material_storage_id == SizeMaterialStorage.size_material_storage_id)
-             .join(SPUMaterial, SizeMaterialStorage.spu_material_id == SPUMaterial.spu_material_id)
-             .join(Material, SizeMaterialStorage.material_id == Material.material_id)
-             .join(Supplier, Material.material_supplier == Supplier.supplier_id)
-             .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
-             .join(MaterialWarehouse, MaterialType.warehouse_id == MaterialWarehouse.material_warehouse_id))
-    query = query.union(sized_query)
-    if outbound_type_filter:
-        query = query.filter(OutboundRecord.outbound_type == outbound_type_filter)
-    if warehouse_filter:
-        query = query.filter(MaterialWarehouse.warehouse_id == warehouse_filter)
-    if supplier_name_filter:
-        query = query.filter(Supplier.supplier_name.ilike(f"%{supplier_name_filter}%"))
-    if date_range_filter_start:
-        query = query.filter(OutboundRecord.outbound_datetime >= date_range_filter_start)
-    if date_range_filter_end:
-        query = query.filter(OutboundRecord.outbound_datetime <= date_range_filter_end)
-    if material_model_filter:
-        query = query.filter(SPUMaterial.material_model.ilike(f"%{material_model_filter}%"))
-    total_count = query.distinct().count()
-    response_entities = query.distinct().limit(page_size).offset((page_num - 1) * page_size).all()
-    outbound_records = []
-    department_mapping = {entity.department_id:entity.department_name for entity in db.session.query(Department).all()}
-    for outbound_record, outbound_record_detail, material, supplier, material_type, material_warehouse, spu, avg_price in response_entities:
-        res = db_obj_to_res(outbound_record, OutboundRecord, attr_name_list=OUTBOUND_RECORD_SELECTABLE_TABLE_ATTRNAMES)
-        res = db_obj_to_res(outbound_record_detail, OutboundRecordDetail, attr_name_list=OUTBOUND_RECORD_DETAIL_SELECTABLE_TABLE_ATTRNAMES,initial_res=res)
-        res = db_obj_to_res(spu, SPUMaterial, attr_name_list=SPU_MATERIAL_TABLE_ATTRNAMES, initial_res=res)
-        res = db_obj_to_res(material, Material, attr_name_list=MATERIAL_SELECTABLE_TABLE_ATTRNAMES,initial_res=res)
-        res = db_obj_to_res(supplier, Supplier,attr_name_list=SUPPLIER_SELECTABLE_TABLE_ATTRNAMES,initial_res=res)
-        res[to_camel('unit_price')] = avg_price
-        res[to_camel('outbound_datetime')] = format_datetime(outbound_record.outbound_datetime)
-        res[to_camel('outbound_type')] = format_outbound_type(outbound_record.outbound_type)
-        res[to_camel('outbound_department')] = department_mapping[outbound_record.outbound_department]
-        outbound_records.append(res)
-    return jsonify({'outboundRecords':outbound_records, "total":total_count}), 200
+#     sized_query = (db.session.query(OutboundRecord, OutboundRecordDetail, Material, Supplier, MaterialType, MaterialWarehouse, SPUMaterial, SizeMaterialStorage.average_price)
+#              .join(OutboundRecordDetail, OutboundRecord.outbound_record_id == OutboundRecordDetail.outbound_record_id)
+#              .join(SizeMaterialStorage, OutboundRecordDetail.size_material_storage_id == SizeMaterialStorage.size_material_storage_id)
+#              .join(SPUMaterial, SizeMaterialStorage.spu_material_id == SPUMaterial.spu_material_id)
+#              .join(Material, SizeMaterialStorage.material_id == Material.material_id)
+#              .join(Supplier, Material.material_supplier == Supplier.supplier_id)
+#              .join(MaterialType, Material.material_type_id == MaterialType.material_type_id)
+#              .join(MaterialWarehouse, MaterialType.warehouse_id == MaterialWarehouse.material_warehouse_id))
+#     query = query.union(sized_query)
+#     if outbound_type_filter:
+#         query = query.filter(OutboundRecord.outbound_type == outbound_type_filter)
+#     if warehouse_filter:
+#         query = query.filter(MaterialWarehouse.warehouse_id == warehouse_filter)
+#     if supplier_name_filter:
+#         query = query.filter(Supplier.supplier_name.ilike(f"%{supplier_name_filter}%"))
+#     if date_range_filter_start:
+#         query = query.filter(OutboundRecord.outbound_datetime >= date_range_filter_start)
+#     if date_range_filter_end:
+#         query = query.filter(OutboundRecord.outbound_datetime <= date_range_filter_end)
+#     if material_model_filter:
+#         query = query.filter(SPUMaterial.material_model.ilike(f"%{material_model_filter}%"))
+#     total_count = query.distinct().count()
+#     response_entities = query.distinct().limit(page_size).offset((page_num - 1) * page_size).all()
+#     outbound_records = []
+#     department_mapping = {entity.department_id:entity.department_name for entity in db.session.query(Department).all()}
+#     for outbound_record, outbound_record_detail, material, supplier, material_type, material_warehouse, spu, avg_price in response_entities:
+#         res = db_obj_to_res(outbound_record, OutboundRecord, attr_name_list=OUTBOUND_RECORD_SELECTABLE_TABLE_ATTRNAMES)
+#         res = db_obj_to_res(outbound_record_detail, OutboundRecordDetail, attr_name_list=OUTBOUND_RECORD_DETAIL_SELECTABLE_TABLE_ATTRNAMES,initial_res=res)
+#         res = db_obj_to_res(spu, SPUMaterial, attr_name_list=SPU_MATERIAL_TABLE_ATTRNAMES, initial_res=res)
+#         res = db_obj_to_res(material, Material, attr_name_list=MATERIAL_SELECTABLE_TABLE_ATTRNAMES,initial_res=res)
+#         res = db_obj_to_res(supplier, Supplier,attr_name_list=SUPPLIER_SELECTABLE_TABLE_ATTRNAMES,initial_res=res)
+#         res[to_camel('unit_price')] = avg_price
+#         res[to_camel('outbound_datetime')] = format_datetime(outbound_record.outbound_datetime)
+#         res[to_camel('outbound_type')] = format_outbound_type(outbound_record.outbound_type)
+#         res[to_camel('outbound_department')] = department_mapping[outbound_record.outbound_department]
+#         outbound_records.append(res)
+#     return jsonify({'outboundRecords':outbound_records, "total":total_count}), 200
     
 @accounting_warehouse_bp.route("/accounting/get_warehouse_inbound_record", methods=["GET"])
 def get_warehouse_inbound_record():
@@ -180,25 +182,16 @@ def get_warehouse_inbound_record():
     order_rid_filter = request.args.get('orderRidFilter', type=str)
     # approval_status_filter = request.args.get('approvalStatusFilter', type=str)
     # print(approval_status_filter)
-    query = (db.session.query(InboundRecord,InboundRecordDetail, Material, Supplier,SPUMaterial,Order.order_rid)
+    query = (db.session.query(InboundRecord,InboundRecordDetail,Supplier,SPUMaterial,Material,Order.order_rid,MaterialStorage)
                 .join(Supplier, InboundRecord.supplier_id == Supplier.supplier_id)
                 .join(InboundRecordDetail, InboundRecord.inbound_record_id == InboundRecordDetail.inbound_record_id)
                 .join(MaterialStorage, InboundRecordDetail.material_storage_id == MaterialStorage.material_storage_id)
-                .join(Material, MaterialStorage.material_id == Material.material_id)
                 .join(SPUMaterial, MaterialStorage.spu_material_id == SPUMaterial.spu_material_id)
+                .join(Material, SPUMaterial.material_id == Material.material_id)
                 .outerjoin(Order, InboundRecordDetail.order_id == Order.order_id)
                 )
-    
-    sized_material_query = (db.session.query(InboundRecord,InboundRecordDetail, Material, Supplier,SPUMaterial, Order.order_rid)
-                .join(Supplier, InboundRecord.supplier_id == Supplier.supplier_id)
-                .join(InboundRecordDetail, InboundRecord.inbound_record_id == InboundRecordDetail.inbound_record_id)
-                .join(SizeMaterialStorage, InboundRecordDetail.size_material_storage_id == SizeMaterialStorage.size_material_storage_id)
-                .join(Material, SizeMaterialStorage.material_id == Material.material_id)
-                .join(SPUMaterial, SizeMaterialStorage.spu_material_id == SPUMaterial.spu_material_id)
-                .outerjoin(Order, InboundRecordDetail.order_id == Order.order_id)
-                )
-
-    query = query.union(sized_material_query).order_by(InboundRecord.inbound_datetime.desc())
+    # order by time
+    query = query.order_by(InboundRecord.inbound_datetime.desc())
 
     if inbound_rid_filter:
         query = query.filter(InboundRecord.inbound_rid.ilike(f"%{inbound_rid_filter}%"))
@@ -231,16 +224,17 @@ def get_warehouse_inbound_record():
     total_count = query.distinct().count()
     response_entities = query.distinct().limit(page_size).offset((page_num - 1) * page_size).all()
     inbound_records = []
-    for inbound_record, inbound_record_detail, material, supplier, spu, order_rid in response_entities:
+    for inbound_record, inbound_record_detail, supplier, spu, material, order_rid, material_storage in response_entities:
         res = db_obj_to_res(inbound_record, InboundRecord,attr_name_list=type_to_attr_mapping["InboundRecord"])
         res = db_obj_to_res(inbound_record_detail, InboundRecordDetail,attr_name_list=type_to_attr_mapping['InboundRecordDetail'],initial_res=res)
-        res = db_obj_to_res(material, Material,attr_name_list=type_to_attr_mapping['Material'],initial_res=res)
         res = db_obj_to_res(supplier, Supplier,attr_name_list=type_to_attr_mapping['Supplier'],initial_res=res)
         res = db_obj_to_res(spu, SPUMaterial, attr_name_list = type_to_attr_mapping['SPUMaterial'], initial_res=res)
+        res = db_obj_to_res(material, Material, attr_name_list=type_to_attr_mapping['Material'], initial_res = res)
         res[to_camel('inbound_datetime')] = format_datetime(inbound_record.inbound_datetime)
         res[to_camel('approval_status')] = accounting_audit_status_converter(inbound_record.approval_status)
         res[to_camel('material_warehouse')] = warehouse_id_mapping[inbound_record.warehouse_id] if inbound_record.warehouse_id in warehouse_id_mapping.keys() else ''
         res[to_camel('order_rid')] = order_rid
+        res[to_camel('actual_inbound_unit')] = material_storage.actual_inbound_unit
         inbound_records.append(res)
     return jsonify({"inboundRecords":inbound_records, "total":total_count}), 200
 
@@ -543,4 +537,115 @@ def create_inbound_summary_excel_and_download():
     time_range_string = date_range_filter_start + "至" + date_range_filter_end if date_range_filter_start and date_range_filter_end else "全部"
     generate_accounting_summary_excel(template_path, save_path, warehouse_filter, supplier_name_filter, material_model_filter,time_range_string ,inbound_summary)
     return send_file(save_path, as_attachment=True, download_name=new_file_name)
+
+
+@accounting_warehouse_bp.route("/accounting/test", methods=["GET"])
+def test():
+    old_material_storage_count = len(db.session.query(OldMaterialStorage).all())
+    old_size_material_storage_count = len(db.session.query(OldSizeMaterialStorage).all())
+    new_material_storage_count = len(db.session.query(MaterialStorage).all())
+    print("old material storage has number of " + str(old_material_storage_count) + " of records")
+    print("old size material storage has number of " + str(old_size_material_storage_count) + " of records")
+    print("new material storage has number of " + str(new_material_storage_count) + " of records")
+    inbound_record_detail_count = len(db.session.query(InboundRecordDetail).all())
     
+    inbound_record_detail_actual = len(db.session.query(InboundRecordDetail, InboundRecord).join(InboundRecord, InboundRecord.inbound_record_id == InboundRecordDetail.inbound_record_id).all())
+    print("inbound_record_detail has " + str(inbound_record_detail_count))
+    print("actual inbound record detail has " + str(inbound_record_detail_actual))
+    return "OK", 200
+@accounting_warehouse_bp.route("/accounting/syncmaterialstorage", methods=["GET"])
+def sync_material_storage():
+    def display_sync_info():
+        old_material_storage_count = len(db.session.query(OldMaterialStorage).all())
+        old_size_material_storage_count = len(db.session.query(OldSizeMaterialStorage).all())
+        new_material_storage_count = len(db.session.query(MaterialStorage).all())
+        print("old material storage has number of " + str(old_material_storage_count) + " of records")
+        print("old size material storage has number of " + str(old_size_material_storage_count) + " of records")
+        print("new material storage has number of " + str(new_material_storage_count) + " of records")
+    display_sync_info()
+    attr_names = ["order_id", "order_shoe_id", "spu_material_id","current_amount", "unit_price", "material_outsource_status", "material_outsource_date",
+                  "material_estimated_arrival_date", "spu_material_id", "actual_inbound_unit","craft_name", "average_price", "material_storage_status"]
+    count = 0
+    total = str(len(db.session.query(OldMaterialStorage).all()))
+    for entity in db.session.query(OldMaterialStorage).all():
+        if count % 100 == 0:
+            print(str(count) + " / " + total)
+        new_entity = MaterialStorage()
+        for attr in attr_names:
+            setattr(new_entity, attr, getattr(entity, attr) if getattr(entity, attr) else None)
+        new_entity.inbound_amount = entity.actual_inbound_amount if entity.actual_inbound_amount else None
+        db.session.add(new_entity)
+        db.session.flush()
+        old_ms_new_ms_mapping[entity.material_storage_id] = new_entity.material_storage_id
+        count += 1
+    db.session.commit()
+    display_sync_info()
+    print("unsized mapping has " + str(len(old_ms_new_ms_mapping.keys())))
+    return "request OK", 200
+
+@accounting_warehouse_bp.route("/accounting/syncsizematerialstorage", methods=["GET"])
+def sync_size_material_storage():
+    def display_sync_info():
+        old_size_material_storage_count = len(db.session.query(OldSizeMaterialStorage).all())
+        new_material_storage_count = len(db.session.query(MaterialStorage).all())
+        print("old size material storage has number of " + str(old_size_material_storage_count) + " of records")
+        print("new material storage has number of " + str(new_material_storage_count) + " of records")
+    display_sync_info()
+    attr_names = ["order_id", "order_shoe_id", "spu_material_id","size_34_current_amount","size_35_current_amount"
+                  ,"size_36_current_amount"
+                  ,"size_37_current_amount"
+                  ,"size_38_current_amount"
+                  ,"size_39_current_amount"
+                  ,"size_40_current_amount"
+                  ,"size_41_current_amount"
+                  ,"size_42_current_amount"
+                  ,"size_43_current_amount"
+                  ,"size_44_current_amount"
+                  ,"size_45_current_amount"
+                  ,"size_46_current_amount"
+                  , "unit_price", "material_outsource_status", "material_outsource_date",
+                  "material_estimated_arrival_date", "spu_material_id","craft_name", "average_price", "material_storage_status","actual_inbound_unit"]
+    count = 0
+    total = str(len(db.session.query(OldSizeMaterialStorage).all()))
+    for entity in db.session.query(OldSizeMaterialStorage).all():
+        if count % 100 == 0:
+            print(str(count) + " / " + total)
+        new_entity = MaterialStorage()
+        for attr in attr_names:
+            setattr(new_entity, attr, getattr(entity, attr) if getattr(entity, attr) else None)
+            for i in range(34, 47, 1):
+                setattr(new_entity, "size_"+str(i)+"_inbound_amount", getattr(entity, "size_" + str(i) + "_actual_inbound_amount"))
+        db.session.add(new_entity)
+        db.session.flush()
+        size_ms_mapping[entity.size_material_storage_id] = new_entity.material_storage_id
+        count += 1
+    db.session.commit()
+    display_sync_info()
+    print("size mapping has " + str(len(size_ms_mapping.keys())))
+    return "request OK", 200
+
+
+# @accounting_warehouse_bp.route("accounting/syncsizematerialstorageid", methods=["GET"])
+# def sync_size_material_storage_id():
+#     return 
+@accounting_warehouse_bp.route("/accounting/syncmateiralstorageid", methods=["GET"])
+def sync_material_storage_id():
+    print("unsized mapping has " + str(len(old_ms_new_ms_mapping.keys())) + " number of keys")
+    print("sized mapping has " + str(len(size_ms_mapping.keys())))
+    total = str(len(db.session.query(InboundRecordDetail).all()))
+    print(max(old_ms_new_ms_mapping.keys()))
+    print(max(size_ms_mapping.keys()))
+    print("inbound_record_detail has " + str(len(db.session.query(InboundRecordDetail).all())) + " number of records")
+    count = 0
+    for entity, _ in db.session.query(InboundRecordDetail, InboundRecord).join(InboundRecord, InboundRecord.inbound_record_id == InboundRecordDetail.inbound_record_id).all():
+        if count % 100 == 0:
+            print(str(count) + " / " + total)
+        if entity.material_storage_id == None:
+            entity.material_storage_id = size_ms_mapping[entity.size_material_storage_id]
+        else:
+            entity.material_storage_id = old_ms_new_ms_mapping[entity.material_storage_id]
+        db.session.flush()
+        count += 1
+    db.session.commit()
+    return "request OK", 200
+

--- a/backend-python/accounting/payable_management.py
+++ b/backend-python/accounting/payable_management.py
@@ -57,6 +57,7 @@ def add_transactions():
     return {"msg":"all transactions added"}, 200
 @payable_management_bp.route('/payable_management/get_payable_info', methods=['GET'])
 def get_payable_info():
+    return "OK", 200
     payable_object_accounts = (db.session.query(AccountingPayableAccount, AccountingPayeePayer)
                                .join(AccountingPayeePayer, AccountingPayableAccount.account_owner_id == AccountingPayeePayer.payee_id)
                                .all())
@@ -99,6 +100,7 @@ def get_payable_info():
 
 @payable_management_bp.route('/payable_management/get_payable_info_new', methods=['GET'])
 def get_payable_info_new():
+    return "OK", 200
     payable_object_accounts = (db.session.query(AccountingPayableAccount, AccountingPayeePayer)
                                .join(AccountingPayeePayer, AccountingPayableAccount.account_owner_id == AccountingPayeePayer.payee_id)
                                .all())

--- a/backend-python/backend_config.json
+++ b/backend-python/backend_config.json
@@ -1,7 +1,7 @@
 {
     "db_username": "jiancheng_dev1",
     "db_password": "123456Ab",
-    "db_name": "jiancheng",
+    "db_name": "jiancheng_new",
     "db_host": "rm-wz9e6065n2281l3i56o.mysql.rds.aliyuncs.com",
     "secret_key": "EC63AF9BA57B9F20",
     "jwt_secret_key": "EC63AF9BA57B9F20",

--- a/backend-python/models.py
+++ b/backend-python/models.py
@@ -204,7 +204,7 @@ class MaterialStorage(db.Model):
     current_amount = db.Column(DECIMAL(13, 5), nullable=False, default=0)
     unit_price = db.Column(DECIMAL(13, 4), default=0)
     material_outsource_status = db.Column(TINYINT, nullable=False, default=0)
-    material_outsource_outbound_date = db.Column(DATE, nullable=True)
+    material_outsource_date = db.Column(DATE, nullable=True)
     material_estimated_arrival_date = db.Column(DATE, nullable=True)
     actual_inbound_unit = db.Column(CHAR(5), nullable=True)
     spu_material_id = db.Column(INTEGER, nullable=True)
@@ -213,7 +213,7 @@ class MaterialStorage(db.Model):
     batch_info_type_id = db.Column(INTEGER, nullable=True)
     material_storage_status = db.Column(CHAR(1), nullable=True)
     shoe_size_columns = db.Column(JSON, nullable=True)
-
+    craft_name = db.Column(CHAR(200), nullable=True)
     # Current amounts per size
     size_34_current_amount = db.Column(INTEGER, nullable=True)
     size_35_current_amount = db.Column(INTEGER, nullable=True)
@@ -258,6 +258,155 @@ class MaterialStorage(db.Model):
         """Convert SQLAlchemy object to dictionary."""
         return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
 
+class OldMaterialStorage(db.Model):
+    __tablename__ = "old_material_storage"
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "actual_inbound_material_id",
+            "inbound_model",
+            "inbound_specification",
+            "actual_inbound_unit",
+            "material_storage_color",
+            "order_shoe_id",
+            name="unq_material_storage",
+        ),
+    )
+
+    material_storage_id = db.Column(
+        db.BigInteger, primary_key=True, autoincrement=True, nullable=False
+    )
+    material_model = db.Column(db.String(50), default="", nullable=True)
+    order_id = db.Column(db.BigInteger)
+    order_shoe_id = db.Column(db.BigInteger)
+    material_id = db.Column(db.BigInteger, nullable=False)
+    estimated_inbound_amount = db.Column(
+        db.DECIMAL(12, 5),
+        default=0,
+    )
+    actual_purchase_amount = db.Column(
+        db.DECIMAL(12, 5),
+        default=0,
+    )
+    actual_inbound_amount = db.Column(
+        db.DECIMAL(12, 5),
+        default=0,
+    )
+    current_amount = db.Column(db.DECIMAL(12, 5), default=0, nullable=False)
+    unit_price = db.Column(db.DECIMAL(13, 4), nullable=True, default=0.00)
+    average_price = db.Column(db.DECIMAL(13, 4), nullable=True, default=0.00)
+    material_specification = db.Column(db.String(100), default="", nullable=True)
+    material_outsource_status = db.Column(db.SmallInteger, default=0, nullable=False)
+    material_outsource_date = db.Column(db.Date)
+    material_storage_color = db.Column(db.String(40), default="", nullable=True)
+    total_purchase_order_id = db.Column(db.BigInteger, nullable=True)
+    material_estimated_arrival_date = db.Column(db.Date)
+    material_storage_status = db.Column(db.SmallInteger, default=0)
+    department_id = db.Column(db.Integer)
+
+    craft_name = db.Column(db.String(200), nullable=True)
+    composite_unit_cost = db.Column(db.DECIMAL(12, 3), default=0.00)
+    production_instruction_item_id = db.Column(db.BigInteger, nullable=True)
+    actual_inbound_unit = db.Column(db.String(5), nullable=True)
+    actual_inbound_material_id = db.Column(db.BigInteger, nullable=True)
+    inbound_model = db.Column(db.String(50), nullable=True)
+    inbound_specification = db.Column(db.String(100), nullable=True)
+    spu_material_id = db.Column(db.Integer, nullable=True)
+
+    def __repr__(self):
+        return f"<MaterialStorage(material_storage_id={self.material_storage_id})>"
+
+    def __name__(self):
+        return "MaterialStorage"
+
+    def to_dict(obj):
+        """Convert SQLAlchemy object to dictionary."""
+        return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+
+
+
+
+
+
+class OldSizeMaterialStorage(db.Model):
+    __tablename__ = "old_size_material_storage"
+    size_material_storage_id = db.Column(
+        db.BigInteger, primary_key=True, autoincrement=True
+    )
+    size_material_specification = db.Column(db.String(100), default="", nullable=False)
+    size_material_model = db.Column(db.String(50), default="", nullable=True)
+    size_34_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_35_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_36_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_37_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_38_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_39_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_40_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_41_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_42_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_43_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_44_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_45_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_46_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    total_estimated_inbound_amount = db.Column(db.Integer, default=0)
+    size_34_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_35_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_36_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_37_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_38_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_39_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_40_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_41_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_42_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_43_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_44_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_45_actual_inbound_amount = db.Column(db.Integer, default=0)
+    size_46_actual_inbound_amount = db.Column(db.Integer, default=0)
+    total_actual_inbound_amount = db.Column(db.Integer, default=0)
+    material_outsource_status = db.Column(db.SmallInteger, default=0, nullable=False)
+    size_34_current_amount = db.Column(db.Integer, default=0)
+    size_35_current_amount = db.Column(db.Integer, default=0)
+    size_36_current_amount = db.Column(db.Integer, default=0)
+    size_37_current_amount = db.Column(db.Integer, default=0)
+    size_38_current_amount = db.Column(db.Integer, default=0)
+    size_39_current_amount = db.Column(db.Integer, default=0)
+    size_40_current_amount = db.Column(db.Integer, default=0)
+    size_41_current_amount = db.Column(db.Integer, default=0)
+    size_42_current_amount = db.Column(db.Integer, default=0)
+    size_43_current_amount = db.Column(db.Integer, default=0)
+    size_44_current_amount = db.Column(db.Integer, default=0)
+    size_45_current_amount = db.Column(db.Integer, default=0)
+    size_46_current_amount = db.Column(db.Integer, default=0)
+    total_current_amount = db.Column(db.Integer, default=0)
+    size_storage_type = db.Column(db.String(10), nullable=False, default="E")
+    material_outsource_date = db.Column(db.Date, nullable=True)
+    material_id = db.Column(
+        db.BigInteger,
+    )
+    department_id = db.Column(
+        db.Integer,
+    )
+    size_material_color = db.Column(db.String(40), default="", nullable=True)
+    order_id = db.Column(db.BigInteger)
+    order_shoe_id = db.Column(db.BigInteger)
+    unit_price = db.Column(db.DECIMAL(13, 4), nullable=True, default=0.00)
+    average_price = db.Column(db.DECIMAL(13, 4), nullable=True, default=0.00)
+    total_purchase_order_id = db.Column(db.BigInteger)
+    material_estimated_arrival_date = db.Column(db.Date)
+    material_storage_status = db.Column(db.SmallInteger, default=0)
+    craft_name = db.Column(db.String(200), nullable=True)
+    production_instruction_item_id = db.Column(db.BigInteger, nullable=True)
+    shoe_size_columns = db.Column(db.JSON, nullable=True)
+    spu_material_id = db.Column(db.Integer, nullable=True)
+    actual_inbound_unit = db.Column(db.String(5), nullable=True)
+
+    def __repr__(self):
+        return f"<SizeMaterialStorage {self.size_material_specification}>"
+
+    def to_dict(obj):
+        """Convert SQLAlchemy object to dictionary."""
+        return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+    
 
 class Operation(db.Model):
     __tablename__ = "operation"

--- a/backend-python/shared_apis/order.py
+++ b/backend-python/shared_apis/order.py
@@ -618,7 +618,7 @@ def get_order_info_business():
                     for db_attr in database_attr_list
                 }
                 # casting decimal to int or float accordingly for frontend
-                if entity.OrderShoeBatchInfo.packaging_info_quantity:
+                if entity.OrderShoeBatchInfo.packaging_info_quantity != None:
                     if entity.OrderShoeBatchInfo.packaging_info_quantity == int(entity.OrderShoeBatchInfo.packaging_info_quantity):
                         temp_obj["unitPerRatio"] = int(entity.OrderShoeBatchInfo.packaging_info_quantity)
                     else:


### PR DESCRIPTION
models.py added old_material_storage and old_size_material_storage
accounting/test                                  display number of entities in three tables
accounting/syncmaterialstorage         add old_material_storage into material_storage and saves the entity id mapping
accounting/syncsizematerialstorage   add old_size_material_storage into material_storage and saves the entity id mapping
accounting/syncmaterialstorageid      modifies the inboundrecorddetail materialstorage_id using the previous mapping
