### PR TITLE
修改进度和排期页面第一版

### DIFF
--- a/backend-python/api_utility.py
+++ b/backend-python/api_utility.py
@@ -4,6 +4,8 @@
 import random
 import string
 from decimal import Decimal
+from datetime import datetime
+
 
 # ### check if a shoe exists in DB
 # def check_shoe_exists(shoe_rid):
@@ -131,6 +133,58 @@ def status_converter(current_status_arr, current_status_value_arr):
         status = "生产中"
     elif 42 in current_status_arr:
         status = "生产结束"
+    return status
+
+
+def estimate_status_converter(production_info):
+    interval1 = [production_info.cutting_start_date, production_info.cutting_end_date]
+    interval2 = [production_info.pre_sewing_start_date, production_info.pre_sewing_end_date]
+    interval3 = [production_info.sewing_start_date, production_info.sewing_end_date]
+    interval4 = [production_info.molding_start_date, production_info.molding_end_date]
+
+    interval1 = [d if d is not None else datetime.max.date() for d in interval1]
+    interval2 = [d if d is not None else datetime.max.date() for d in interval2]
+    interval3 = [d if d is not None else datetime.max.date() for d in interval3]
+    interval4 = [d if d is not None else datetime.max.date() for d in interval4]
+    
+    today = datetime.now().date()
+    result = "未排期"
+    if today < interval1[0]:
+        result = "裁断未开始"
+    elif interval1[0] <= today <= interval1[1]:
+        result = "裁断进行中"
+    elif interval1[1] < today < interval2[0]:
+        result = "预备未开始"
+    elif interval2[0] <= today <= interval2[1]:
+        result = "预备进行中"
+    elif interval2[1] < today < interval3[0]:
+        result = "针车未开始"
+    elif interval3[0] <= today <= interval3[1]:
+        result = "针车进行中"
+    elif interval3[1] < today < interval4[0]:
+        result = "成型未开始"
+    elif interval4[0] <= today <= interval4[1]:
+        result = "成型进行中"
+    elif interval4[1] < today:
+        result = "生产已结束"
+    return result
+
+def scheduling_status_converter(production_info):
+    cutting = [production_info.cutting_start_date, production_info.cutting_end_date]
+    pre_sewing = [production_info.pre_sewing_start_date, production_info.pre_sewing_end_date]
+    sewing = [production_info.sewing_start_date, production_info.sewing_end_date]
+    molding = [production_info.molding_start_date, production_info.molding_end_date]
+
+    if cutting == [None, None]:
+        status = '裁断未排期'
+    elif pre_sewing == [None, None]:
+        status = '预备未排期'
+    elif sewing == [None, None]:
+        status = '针车未排期'
+    elif molding == [None, None]:
+        status = '成型未排期'
+    else:
+        status = '已排期'
     return status
 
 

--- a/backend-python/constants.py
+++ b/backend-python/constants.py
@@ -110,3 +110,12 @@ PRICE_REPORT_GM_APPROVED = "已审批"
 
 
 ACCOUNTING_AUDIT_ROLE = 24
+
+
+SCHEDULING_STATUS_TO_INT = {
+    "裁断未排期": 0,
+    "预备未排期": 1,
+    "针车未排期": 2,
+    "成型未排期": 3,
+    "已排期": 4,
+}

--- a/backend-python/models.py
+++ b/backend-python/models.py
@@ -592,6 +592,7 @@ class OrderShoeProductionInfo(db.Model):
     pre_sewing_start_date = db.Column(db.Date, nullable=True)
     pre_sewing_end_date = db.Column(db.Date, nullable=True)
     is_material_arrived = db.Column(db.Boolean, nullable=False)
+    scheduling_status = db.Column(db.SmallInteger, nullable=False, default=0)
     order_shoe_id = db.Column(
         db.BigInteger,
     )

--- a/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionManagementDepartmentGeneral/components/ProductionScheduling.vue
+++ b/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionManagementDepartmentGeneral/components/ProductionScheduling.vue
@@ -1,0 +1,741 @@
+<template>
+    <el-row :gutter="20" style="margin-top: 20px">
+        <el-col>
+            <OrderSchedulingSearchDialog :searchForm="searchForm"  @updateSearchForm="handleSearch" />
+        </el-col>
+    </el-row>
+    <el-row>
+        <el-col>
+            <el-button type="primary" v-if="role == 6 && isMultipleSelection" @click="openMultipleShoesDialog">
+                排期
+            </el-button>
+            <el-button type="primary" v-if="role == 6" @click="toggleSelectionMode">
+                {{ isMultipleSelection ? "退出" : "多选鞋型排期" }}
+            </el-button>
+            <p v-if="isSelectedRowsEmpty">未选择鞋型</p>
+        </el-col>
+    </el-row>
+    <el-row :gutter="20">
+        <el-col :span="24" :offset="0">
+            <el-table :data="orderTableData" stripe border style="height: 600px"
+                @selection-change="handleSelectionChange">
+                <el-table-column type="selection" width="55"></el-table-column>
+                <el-table-column prop="orderRid" label="订单号"></el-table-column>
+                <el-table-column prop="shoeRid" label="工厂型号"></el-table-column>
+                <el-table-column prop="startDate" label="订单开始"></el-table-column>
+                <el-table-column prop="cuttingStartDate" label="裁断开始"></el-table-column>
+                <el-table-column prop="cuttingEndDate" label="裁断结束"></el-table-column>
+                <el-table-column prop="preSewingStartDate" label="预备开始"></el-table-column>
+                <el-table-column prop="preSewingEndDate" label="预备结束"></el-table-column>
+                <el-table-column prop="sewingStartDate" label="针车开始"></el-table-column>
+                <el-table-column prop="sewingEndDate" label="针车结束"></el-table-column>
+                <el-table-column prop="moldingStartDate" label="成型开始"></el-table-column>
+                <el-table-column prop="moldingEndDate" label="成型结束"></el-table-column>
+                <el-table-column prop="schedulingStatus" label="排期状态"></el-table-column>
+                <el-table-column label="排期">
+                    <template #default="scope">
+                        <el-button type="primary" size="small" @click="openScheduleDialog(scope.row)">
+                            查看
+                        </el-button>
+                    </template>
+                </el-table-column>
+            </el-table>
+        </el-col>
+    </el-row>
+    <el-row :gutter="20">
+        <el-col>
+            <el-pagination @size-change="handleSizeChange" @current-change="handlePageChange"
+                :current-page="currentPage" :page-size="pageSize"
+                layout="total, sizes, prev, pager, next, jumper" :total="orderTotalRows" />
+        </el-col>
+    </el-row>
+
+    <el-dialog title="多鞋型排期页面" v-model="isMultipleShoesDialogVis" width="50%">
+        <el-form :model="multipleShoesScheduleForm" :rules="rules" ref="multipleShoesScheduleForm" class="custom-form">
+            <el-form-item label="裁断生产周期" prop="cuttingDateRange">
+                <el-date-picker v-model="multipleShoesScheduleForm.cuttingDateRange" type="daterange" size="default"
+                    range-separator="至" value-format="YYYY-MM-DD">
+                </el-date-picker>
+            </el-form-item>
+            <el-form-item label="针车预备生产周期" prop="preSewingDateRange">
+                <el-date-picker v-model="multipleShoesScheduleForm.preSewingDateRange" type="daterange" size="default"
+                    range-separator="至" value-format="YYYY-MM-DD">
+                </el-date-picker>
+            </el-form-item>
+            <el-form-item label="针车生产周期" prop="sewingDateRange">
+                <el-date-picker v-model="multipleShoesScheduleForm.sewingDateRange" type="daterange" size="default"
+                    range-separator="至" value-format="YYYY-MM-DD">
+                </el-date-picker>
+            </el-form-item>
+            <el-form-item label="成型生产周期" prop="moldingDateRange">
+                <el-date-picker v-model="multipleShoesScheduleForm.moldingDateRange" type="daterange" size="default"
+                    range-separator="至" value-format="YYYY-MM-DD">
+                </el-date-picker>
+            </el-form-item>
+        </el-form>
+        <template #footer>
+            <span>
+                <el-button type="primary" @click="isMultipleShoesDialogVis = false">返回</el-button>
+                <el-button type="primary" @click="saveMultipleSchedules">保存</el-button>
+            </span>
+        </template>
+    </el-dialog>
+
+    <el-dialog :title="`订单${currentRow.orderRId}-鞋型${currentRow.shoeRId}排期信息`" v-model="isScheduleDialogOpen"
+        fullscreen>
+        <el-tabs v-model="activeTab" tab-position="top" @tab-click="">
+            <el-tab-pane v-for="tab in tabs" :key="tab.name" :label="tab.label" :name="tab.name"
+                :disabled="disableTab(tab.name)">
+                <el-row :gutter="20">
+                    <el-col :span="4" v-for="subTab in tabs">
+                        {{ `${subTab.dateLabel}: ${subTab.dateValue[0] ? subTab.dateValue[0] + '至' + subTab.dateValue[1]
+                            :
+                            '未设置'}` }}
+                    </el-col>
+
+                </el-row>
+                <el-row :gutter="20">
+                    <el-col :span="10" :offset="0">
+                        <span>
+                            {{ tab.dateLabel }}：
+                            <el-date-picker v-model="tab.dateValue" type="daterange" size="default" range-separator="-"
+                                value-format="YYYY-MM-DD" :readonly="!(role == 6)">
+                            </el-date-picker>
+                        </span>
+                        <el-button type="primary" size="default" @click="checkDateProductionStatus(tab)">{{
+                            tab.isDateStatusTableVis ? '关闭表格' : '查看工期内排期情况' }}</el-button>
+                    </el-col>
+                    <el-col :span="8" :offset="6">
+                        <el-descriptions title="" border v-if="role == 6">
+                            <el-descriptions-item label="外包状态">
+                                <div v-if="tab.isOutsourced == 0">
+                                    未设置外包
+                                </div>
+                                <div v-else>
+                                    已设置外包
+                                </div>
+                            </el-descriptions-item>
+                            <el-descriptions-item label="操作">
+                                <el-button v-if="tab.isOutsourced == 0" type="primary" size="default"
+                                    @click="openOutsourceFlow()">启动外包流程</el-button>
+                                <el-button-group v-else>
+                                    <el-button type="primary" size="default"
+                                        @click="openOutsourceFlow()">查看外包流程</el-button>
+                                </el-button-group>
+                            </el-descriptions-item>
+                        </el-descriptions>
+                    </el-col>
+                </el-row>
+                <el-row :gutter="20">
+                    <el-col>
+                        <el-table v-if="tab.isDateStatusTableVis" :data="tab.dateStatusTable" border stripe
+                            height="400px">
+                            <el-table-column type="expand">
+                                <template #default="props">
+                                    <el-table :data="props.row.detail" border stripe>
+                                        <el-table-column type="index" />
+                                        <el-table-column label="订单号" prop="orderRId" />
+                                        <el-table-column label="工厂型号" prop="shoeRId" />
+                                        <el-table-column label="鞋型总数量" prop="totalAmount" />
+                                        <el-table-column label="工段生产开始" prop="productionStartDate" />
+                                        <el-table-column label="工段生产结束" prop="productionEndDate" />
+                                        <el-table-column label="平均每天数量" prop="averageAmount" />
+                                    </el-table>
+                                </template>
+                            </el-table-column>
+
+                            <el-table-column prop="date" label="日期"> </el-table-column>
+                            <el-table-column prop="orderShoeCount" label="已排期鞋型数"> </el-table-column>
+                            <el-table-column prop="predictAmount" label="预计当日现有生产量"> </el-table-column>
+                        </el-table>
+                    </el-col>
+                </el-row>
+                <el-row>
+                    计划自产数量
+                </el-row>
+                <el-row :gutter="20">
+                    <el-col>
+                        <el-table v-loading="isLoading" :data="tab.productionAmountTable" border stripe
+                            :max-height="500">
+                            <el-table-column prop="colorName" label="颜色"></el-table-column>
+                            <el-table-column prop="totalAmount" label="颜色总数"></el-table-column>
+                            <!-- <el-table-column prop="" label="已设置外包数量"></el-table-column> -->
+                            <el-table-column v-for="column in filteredColumns" :key="column.prop" :prop="column.prop"
+                                :label="column.label">
+                                <template v-slot="scope">
+                                    <el-input-number v-model="scope.row[column.prop]" v-if="role == 6" :min="0"
+                                        :step="1" />
+                                    <span v-else>{{ scope.row[column.prop] }}</span>
+                                </template>
+                            </el-table-column>
+                        </el-table>
+                    </el-col>
+                </el-row>
+            </el-tab-pane>
+        </el-tabs>
+        <el-row :gutter="20" style="margin-top: 20px">
+            <el-col :span="24" :offset="0">
+                订单数量
+                <el-table v-loading="isLoading" :data="shoeBatchInfo" :span-method="spanMethod" border stripe
+                    :max-height="500">
+                    <el-table-column prop="colorName" label="颜色"></el-table-column>
+                    <el-table-column prop="totalAmount" label="颜色总数"></el-table-column>
+                    <el-table-column v-for="column in filteredColumns" :key="column.prop" :prop="column.prop"
+                        :label="column.label"></el-table-column>
+                </el-table>
+            </el-col>
+        </el-row>
+        <el-row :gutter="20" style="margin-top: 20px">
+            <el-col :span="24" :offset="0">
+                商务部工艺备注
+                <el-input v-model="currentRow.technicalRemark" autosize type="textarea" readonly />
+            </el-col>
+        </el-row>
+        <el-row :gutter="20" style="margin-top: 20px">
+            <el-col :span="24" :offset="0">
+                商务部材料备注
+                <el-input v-model="currentRow.materialRemark" autosize type="textarea" readonly />
+            </el-col>
+        </el-row>
+        <template #footer>
+            <span>
+                <el-button @click="isScheduleDialogOpen = false">取消</el-button>
+                <el-button type="primary" @click="openProdDetailDialog(this.currentRow)">查看生产信息</el-button>
+                <el-button v-if="role == 6"
+                    type="success" @click="startProduction">下发排期</el-button>
+            </span>
+        </template>
+    </el-dialog>
+</template>
+<script>
+import AllHeader from '@/components/AllHeader.vue'
+import axios from 'axios'
+import { ElMessage, ElMessageBox } from 'element-plus';
+import { shoeBatchInfoTableSpanMethod, getShoeSizesName } from '../../utils'
+import OrderSchedulingSearchDialog from '../../ProductionSharedPages/OrderSchedulingSearchDialog.vue';
+export default {
+    components: {
+        AllHeader,
+        OrderSchedulingSearchDialog,
+    },
+    data() {
+        return {
+            isSearchDialogVisible: false,
+            customerNameOptions: [],
+            searchForm: {
+                orderDateRangeSearch: null,
+                orderRIdSearch: null,
+                shoeRIdSearch: null,
+                customerProductNameSearch: null,
+                statusNodeSearch: null,
+                customerNameSearch: null,
+                customerBrandSearch: null,
+                sortCondition: null
+            },
+            currentProdDetailTab: "1",
+            isProdDetailDialogOpen: false,
+            showFilters: false,
+            filters: [
+                { label: 'Name', value: '', key: 'name' },
+                { label: 'Age', value: '', key: 'age' },
+                // Add more filters here
+            ],
+            isPriceReportDialogOpen: false,
+            currentPriceReportTab: 0,
+            reportPanes: [
+                {
+                    label: '裁断',
+                    key: 0
+                },
+                {
+                    label: '针车预备',
+                    key: 1
+                },
+                {
+                    label: '针车',
+                    key: 2
+                },
+                {
+                    label: '成型',
+                    key: 3
+                }
+            ],
+            role: localStorage.getItem('role'),
+
+            getShoeSizesName,
+            currentPage: 1,
+            pageSize: 10,
+            orderTotalRows: 0,
+            orderTableData: [],
+            currentRow: {},
+            shoeBatchInfo: [],
+            spanMethod: null,
+            logisticsMaterialData: [],
+            logisticsRows: 0,
+            isMaterialLogisticVis: false,
+            logisticsCurrentPage: 1,
+            logisticsPageSize: 10,
+            instruction: false,
+            specification: false,
+            isMultipleSelection: false,
+            selectedRows: [],
+            isMultipleShoesDialogVis: false,
+            multipleShoesScheduleForm: {},
+            multiShoeFormTemplate: {
+                cuttingLineNumbers: null,
+                cuttingDateRange: null,
+                preSewingLineNumbers: null,
+                preSewingDateRange: null,
+                sewingLineNumbers: null,
+                sewingDateRange: null,
+                moldingLineNumbers: null,
+                moldingDateRange: null,
+            },
+            // productionLines,
+            shoeSizes: [],
+            isScheduleDialogOpen: false,
+            shoeSizeColumns: [],
+            activeTab: "cutting",
+            tabs: [],
+            // index 0: 裁断，1：预备，2：针车，3：成型
+            tabsTemplate: [
+                {
+                    name: 'cutting',
+                    label: '裁断排期',
+                    lineLabel: '裁断线号',
+                    dateLabel: '裁断工期',
+                    lineValue: [],
+                    dateValue: [],
+                    dateStatusTable: [],
+                    isOutsourced: 0,
+                    isDateStatusTableVis: false,
+                    productionAmountTable: [],
+                    productionSpanMethod: null,
+                    team: 0
+                },
+                {
+                    name: 'preSewing',
+                    label: '针车预备排期',
+                    lineLabel: '针车预备线号',
+                    dateLabel: '预备工期',
+                    lineValue: [],
+                    dateValue: [],
+                    dateStatusTable: [],
+                    isOutsourced: 0,
+                    isDateStatusTableVis: false,
+                    productionAmountTable: [],
+                    productionSpanMethod: null,
+                    team: 1
+                },
+                {
+                    name: 'sewing',
+                    label: '针车排期',
+                    lineLabel: '针车线号',
+                    dateLabel: '针车工期',
+                    lineValue: [],
+                    dateValue: [],
+                    dateStatusTable: [],
+                    isOutsourced: 0,
+                    isDateStatusTableVis: false,
+                    productionAmountTable: [],
+                    productionSpanMethod: null,
+                    team: 1
+                },
+                {
+                    name: 'molding',
+                    label: '成型排期',
+                    lineLabel: '成型线号',
+                    dateLabel: '成型工期',
+                    lineValue: [],
+                    dateValue: [],
+                    dateStatusTable: [],
+                    isOutsourced: 0,
+                    isDateStatusTableVis: false,
+                    productionAmountTable: [],
+                    productionSpanMethod: null,
+                    team: 2
+                }
+            ],
+            rules: {
+                cuttingLineNumbers: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                cuttingDateRange: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                preSewingLineNumbers: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                preSewingDateRange: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                sewingDateRange: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                sewingDateRange: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                sewingLineNumbers: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                moldingLineNumbers: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+                moldingDateRange: [
+                    { required: true, message: '此项为必填项', trigger: 'change' },
+                ],
+            },
+            isSelectedRowsEmpty: false,
+            priceReportDict: {},
+            isLoading: true,
+            showChild: false,
+        }
+    },
+    async mounted() {
+        this.getAllCustomers()
+        await this.getOrderDataTable()
+    },
+    computed: {
+        filteredColumns() {
+            return this.shoeSizeColumns.filter(column =>
+                this.shoeBatchInfo.some(row => row[column.prop] !== undefined && row[column.prop] !== null && row[column.prop] !== 0)
+            );
+        }
+    },
+    methods: {
+        determineActiveTab() {
+            if (this.currentRow.schedulingStatus === '裁断未排期') {
+                this.activeTab = 'cutting';
+            }
+            else if (this.currentRow.schedulingStatus === '预备未排期') {
+                this.activeTab = 'preSewing';
+            }
+            else if (this.currentRow.schedulingStatus === '针车未排期') {
+                this.activeTab = 'sewing';
+            }
+            else if (this.currentRow.schedulingStatus === '成型未排期') {
+                this.activeTab = 'molding';
+            }
+        },
+        disableTab(tabName) {
+            if (tabName === 'cutting') {
+                return false;
+            }
+            else if (tabName === 'preSewing' && this.currentRow.schedulingStatus !== '裁断未排期') {
+                return false;
+            }
+            else if (tabName === 'sewing') {
+                if (this.currentRow.schedulingStatus !== '裁断未排期' && this.currentRow.schedulingStatus !== '预备未排期') {
+                    return false;
+                }
+            }
+            else if (tabName === 'molding') {
+                if (this.currentRow.schedulingStatus !== '裁断未排期' && this.currentRow.schedulingStatus !== '预备未排期' && this.currentRow.schedulingStatus !== '针车未排期') {
+                    return false;
+                }
+            }
+            return true;
+        },
+        async getAllCustomers() {
+            const response = await axios.get(`${this.$apiBaseUrl}/customer/getallcustomers`)
+            this.customerNameOptions = response.data
+        },
+        updateDialogVisible(newVal) {
+            this.isSearchDialogVisible = newVal
+        },
+        handleSearch(values) {
+            this.searchForm = { ...values }
+            this.getOrderDataTable()
+        },
+        toggleFilters() {
+            this.showFilters = !this.showFilters;
+        },
+        openProdDetailDialog(row) {
+            this.currentRow = row
+            this.showChild = true
+            this.isProdDetailDialogOpen = true
+        },
+        async viewPriceReport(row) {
+            try {
+                let teams = ["裁断", "针车预备", "针车", "成型"]
+                teams.forEach(async (team, index) => {
+                    let params = { "orderShoeId": row.orderShoeId, "team": team, "status": 2 }
+                    let response = await axios.get(`${this.$apiBaseUrl}/production/getpricereportdetailbyordershoeid`, { params })
+                    this.priceReportDict[index] = response.data.detail
+                })
+                this.currentPriceReportTab = 0
+            }
+            catch (error) {
+                console.log(error)
+            }
+            this.isPriceReportDialogOpen = true
+        },
+        async checkDateProductionStatus(tab) {
+            if (tab.isDateStatusTableVis === true) {
+                tab.isDateStatusTableVis = false
+            }
+            else {
+                const params = { "startDate": tab.dateValue[0], "endDate": tab.dateValue[1], "team": tab.name }
+                try {
+                    const response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/checkdateproductionstatus`, { params })
+                    tab.dateStatusTable = response.data
+                    tab.dateStatusTable.forEach(element => {
+                        let amount = 0
+                        element.detail.forEach(row => {
+                            row.averageAmount = this.calculateDailyProduction(row.totalAmount, [row.productionStartDate, row.productionEndDate])
+                            amount += Number(row.averageAmount)
+                        })
+                        element.predictAmount = amount;
+                        tab.isDateStatusTableVis = true
+                    })
+                }
+                catch (error) {
+                    ElMessage.error(error.response.data.message)
+                }
+            }
+        },
+        calculateDailyProduction(totalShoes, dateRange) {
+            if (dateRange && dateRange.length === 2) {
+                const startDate = new Date(dateRange[0]);
+                const endDate = new Date(dateRange[1]);
+                const timeDiff = Math.abs(endDate - startDate);
+                const diffDays = Math.ceil(timeDiff / (1000 * 60 * 60 * 24)) + 1;
+                return (Number(totalShoes) / diffDays).toFixed(2);
+            }
+            return 0;
+        },
+        openOutsourceFlow() {
+            const params = {
+                "orderId": this.currentRow.orderId,
+                "orderRId": this.currentRow.orderRId,
+                "orderShoeId": this.currentRow.orderShoeId,
+                "shoeRId": this.currentRow.shoeRId,
+            }
+            const queryString = new URLSearchParams(params).toString();
+            const url = `${window.location.origin}/productiongeneral/productionoutsource?${queryString}`
+            window.open(url, '_blank')
+        },
+        async openScheduleDialog(row) {
+            this.isLoading = true
+            this.currentRow = row
+            this.determineActiveTab()
+            this.isScheduleDialogOpen = true
+            this.shoeSizeColumns = await this.getShoeSizesName(row.orderId)
+            this.tabs = JSON.parse(JSON.stringify(this.tabsTemplate))
+            this.getOrderShoeScheduleInfo()
+            await this.getOrderShoeBatchInfo()
+            await this.getOutsourceAmount()
+            await this.getOrderShoeProductionAmount()
+            this.isLoading = false
+        },
+        async getOrderShoeScheduleInfo() {
+            let params = { "orderShoeId": this.currentRow.orderShoeId }
+            let response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getordershoescheduleinfo`, { params })
+            response.data.forEach((row, index) => {
+                this.tabs[index].lineValue = row.lineGroup
+                this.tabs[index].dateValue = [row.startDate, row.endDate]
+                this.tabs[index].isOutsourced = row.isOutsourced
+            })
+        },
+        async getOutsourceAmount() {
+            let params = { "orderShoeId": this.currentRow.orderShoeId }
+            let response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getoutsourcebatchinfo`, { params })
+            console.log(response.data)
+        },
+        async getOrderShoeBatchInfo() {
+            this.shoeBatchInfo = []
+            const params = { "orderShoeId": this.currentRow.orderShoeId }
+            const response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getordershoetypeamount`, { params })
+            this.shoeBatchInfo = response.data
+            console.log(this.shoeBatchInfo)
+            this.spanMethod = shoeBatchInfoTableSpanMethod(this.shoeBatchInfo);
+        },
+        async getOrderShoeProductionAmount() {
+            const params = { "orderShoeId": this.currentRow.orderShoeId }
+            const response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getordershoeproductionamount`, { params })
+            this.tabs.forEach(row => {
+                if (response.data[row.team] === undefined) {
+                    row.productionAmountTable = []
+                    let color_totals = {}
+                    this.shoeBatchInfo.forEach(batchInfo => {
+                        if (!(batchInfo.colorName in color_totals)) {
+                            color_totals[batchInfo.colorName] = { ...batchInfo }
+                        }
+                        else {
+                            for (let i = 34; i < 47; i++) {
+                                color_totals[batchInfo.colorName][`size${i}Amount`] += batchInfo[`size${i}Amount`]
+                            }
+                            color_totals[batchInfo.colorName][`pairAmount`] += batchInfo[`pairAmount`]
+                        }
+                    })
+                    for (let color_key in color_totals) {
+                        row.productionAmountTable.push(color_totals[color_key])
+                    }
+                }
+                else {
+                    row.productionAmountTable = response.data[row.team]
+                }
+                // row.productionSpanMethod = shoeBatchInfoTableSpanMethod(row.productionAmountTable)
+            })
+            this.tabs[1].productionAmountTable = this.tabs[2].productionAmountTable
+        },
+        async saveMultipleSchedules() {
+            this.$refs.multipleShoesScheduleForm.validate(async (valid) => {
+                if (valid) {
+                    try {
+                        console.log(this.multipleShoesScheduleForm)
+                        let data = {
+                            "orderShoeIdArr": this.selectedRows.map(row => row.orderShoeId),
+                            "scheduleForm": this.multipleShoesScheduleForm
+                        }
+                        await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/savemultipleschedules`, data)
+                        ElMessage.success("保存成功")
+                    }
+                    catch (error) {
+                        ElMessage.error(error)
+                    }
+                    this.getOrderDataTable()
+                    this.isMultipleShoesDialogVis = false
+                }
+                else {
+                    console.log("testing2")
+                }
+            })
+        },
+        async modifyProductionSchedule() {
+            try {
+                let data = {
+                    "orderShoeId": this.currentRow.orderShoeId,
+                }
+                let infoList = []
+                this.tabs.forEach(row => {
+                    let obj = {
+                        "lineValue": row.lineValue.join(","),
+                        "isOutsourced": row.isOutsourced,
+                        "startDate": row.dateValue[0],
+                        "endDate": row.dateValue[1]
+                    }
+                    infoList.push(obj)
+                })
+                data["productionInfoList"] = infoList
+                await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/editproductionschedule`, data)
+                let temp_data = [this.tabs[0].productionAmountTable, this.tabs[2].productionAmountTable, this.tabs[3].productionAmountTable]
+                data = []
+                temp_data.forEach((table, index) => {
+                    table.forEach(row => {
+                        let obj = {
+                            "productionAmountId": row.productionAmountId,
+                            "orderShoeTypeId": row.orderShoeTypeId,
+                            "productionTeam": index,
+                        }
+                        for (let i = 34; i < 47; i++) {
+                            obj[`size${i}Amount`] = row[`size${i}Amount`]
+                        }
+                        data.push(obj)
+                    })
+                })
+                await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/saveproductionamount`, data)
+                ElMessage.success("修改成功")
+            }
+            catch (error) {
+                ElMessage.error("修改失败")
+            }
+            this.getOrderDataTable()
+            this.isScheduleDialogOpen = false
+        },
+        async startProduction() {
+            ElMessageBox.alert('请确认生产数量和外包数量', '警告', {
+                confirmButtonText: '确认',
+                showCancelButton: true,
+                cancelButtonText: '取消'
+            }).then(async () => {
+                try {
+                    await this.modifyProductionSchedule()
+                    const data = { "orderId": this.currentRow.orderId, "orderShoeId": this.currentRow.orderShoeId }
+                    await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/startproduction`, data)
+                    ElMessage.success("操作成功")
+                }
+                catch (error) {
+                    console.log(error)
+                    ElMessage.error("操作失败")
+                }
+                this.getOrderDataTable()
+                this.isScheduleDialogOpen = false
+            })
+        },
+        openMultipleShoesDialog() {
+            if (this.selectedRows.length == 0) {
+                this.isSelectedRowsEmpty = true
+                return
+            }
+            this.multipleShoesScheduleForm = { ...this.multiShoeFormTemplate }
+            this.isMultipleShoesDialogVis = true
+            this.isSelectedRowsEmpty = false
+        },
+        toggleSelectionMode() {
+            this.isMultipleSelection = !this.isMultipleSelection;
+            this.isSelectedRowsEmpty = false
+        },
+        handleSelectionChange(selection) {
+            this.selectedRows = selection
+        },
+        async handlePageChange(val) {
+            this.currentPage = val
+            await this.getOrderDataTable()
+        },
+        async handleSizeChange(val) {
+            this.pageSize = val
+            await this.getOrderDataTable()
+        },
+        async getOrderDataTable() {
+            let startDate = null, endDate = null
+            if (this.searchForm.orderDateRangeSearch) {
+                startDate = this.searchForm.orderDateRangeSearch[0]
+                endDate = this.searchForm.orderDateRangeSearch[1]
+            }
+            let params = {
+                "page": this.currentPage,
+                "pageSize": this.pageSize,
+                "orderRId": this.searchForm.orderRIdSearch,
+                "shoeRId": this.searchForm.shoeRIdSearch,
+            }
+            let response = await axios.get(`${this.$apiBaseUrl}/production/getorderschedulingprogress`, { params })
+            this.orderTableData = response.data.result
+            this.orderTotalRows = response.data.totalLength
+        },
+        onDialogClose() {
+            // wait until dialog animation is done, then destroy child
+            this.$nextTick(() => {
+                this.showChild = false
+            })
+        }
+    }
+}
+</script>
+<style scoped>
+.error-text {
+    color: red;
+    font-size: 12px;
+}
+
+.custom-form {
+    width: 400px;
+}
+
+.is-readonly .el-input__inner {
+    cursor: not-allowed;
+    background-color: #f5f5f5;
+}
+
+.is-readonly .el-input__suffix {
+    display: none;
+}
+
+.filter-panel {
+    margin-bottom: 20px;
+}
+
+.filters-container {
+    padding: 10px;
+}
+</style>

--- a/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionManagementDepartmentGeneral/views/ProductionManagementDepartmentGeneral.vue
+++ b/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionManagementDepartmentGeneral/views/ProductionManagementDepartmentGeneral.vue
@@ -25,7 +25,10 @@
             class="el-menu-vertical-demo"
           >
             <el-menu-item index="2" @click="handleMenuClick(2)">
-              <span>订单生产明细</span>
+              <span>生产进度</span>
+            </el-menu-item>
+            <el-menu-item index="11" @click="handleMenuClick(11)">
+              <span>订单排期</span>
             </el-menu-item>
             <el-menu-item index="9" @click="handleMenuClick(9)">
               <span>生产报表</span>
@@ -68,11 +71,11 @@ import todotaskDashboard from '../components/TodoTasksView.vue'
 import LogisticInfo from '../components/LogisticInfo.vue'
 import ProductionInfo from '../components/ProductionInfo.vue'
 import OutSourceInfo from '../components/OutSourceInfo.vue'
-import ProductionSchedulingDialogue from '../components/ProductionSchedulingDialogue.vue'
 import ApprovalPage from '../components/ApprovalPage.vue'
 import ProductionManagement from '../components/ProductionManagement.vue'
 import OrderProgress from '../components/OrderProgress.vue'
 import PersonalInfo from '@/components/PersonalInfo.vue'
+import ProductionScheduling from '../components/ProductionScheduling.vue'
 import { UserFilled } from '@element-plus/icons-vue'
 import { ref } from 'vue'
 import axios from 'axios'
@@ -87,14 +90,14 @@ export default {
     ProductionInfo,
     SideMenu,
     LogisticInfo,
-    ProductionSchedulingDialogue,
     OutSourceInfo,
     ApprovalPage,
     ProductionManagement,
     OrderProgress,
     OutsourceFactoryInfo,
     ProductionReport,
-    PersonalInfo
+    PersonalInfo,
+    ProductionScheduling
   },
   data() {
     return {
@@ -117,6 +120,9 @@ export default {
       switch (index) {
         case 2:
           this.currentComponent = 'OrderProgress'
+          break
+        case 11:
+          this.currentComponent = 'ProductionScheduling'
           break
         case 3:
           this.currentComponent = 'LogisticInfo'

--- a/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionSharedPages/OrderProgress.vue
+++ b/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionSharedPages/OrderProgress.vue
@@ -1,26 +1,13 @@
 <template>
-    <el-row :gutter="20" style="margin-top: 20px">
-        <el-col :span="2">
-            <el-button-group>
-                <el-button type="primary" size="default" @click="isSearchDialogVisible = true">搜索设置</el-button>
-            </el-button-group>
-        </el-col>
-        <OrderProgressSearchDialog :visible="isSearchDialogVisible" :customerNameOptions="customerNameOptions"
-            :searchForm="searchForm" @update-visible="updateDialogVisible" @confirm="handleSearch" />
-        <el-col :span="2" style="white-space: nowrap;">
-            <el-button type="primary" v-if="role == 6 && isMultipleSelection" @click="openMultipleShoesDialog">
-                排产
-            </el-button>
-            <el-button type="primary" v-if="role == 6" @click="toggleSelectionMode">
-                {{ isMultipleSelection ? "退出" : "选择鞋型" }}
-            </el-button>
-            <p v-if="isSelectedRowsEmpty">未选择鞋型</p>
+    <el-row :gutter="20">
+        <el-col>
+            <OrderProgressSearchDialog :customerNameOptions="customerNameOptions" :searchForm="searchForm"
+            @updateSearchForm="handleSearch" />
         </el-col>
     </el-row>
-    <el-row :gutter="20" style="margin-top: 20px">
-        <el-col :span="24" :offset="0">
-            <el-table :data="orderTableData" stripe border style="height: 600px"
-                @selection-change="handleSelectionChange">
+    <el-row :gutter="20">
+        <el-col>
+            <el-table :data="orderTableData" stripe border style="height: 40vh">
                 <el-table-column v-if="isMultipleSelection" type="selection" width="55" />
                 <el-table-column label="展开" type="expand">
                     <template #default="prop">
@@ -45,14 +32,14 @@
                         </el-table>
                     </template>
                 </el-table-column>
-                <el-table-column prop="customerName" label="客户名" width="80"></el-table-column>
-                <el-table-column prop="customerBrand" label="商标" width="80"></el-table-column>
+                <el-table-column prop="customerName" label="客户名"></el-table-column>
+                <el-table-column prop="customerBrand" label="商标"></el-table-column>
                 <el-table-column prop="orderRId" label="订单号"></el-table-column>
-                <el-table-column prop="orderStartDate" label="订单开始" width="110"></el-table-column>
-                <el-table-column prop="orderEndDate" label="出货日期" width="110"></el-table-column>
-                <el-table-column prop="shoeRId" label="工厂型号" width="90"></el-table-column>
-                <el-table-column prop="customerProductName" label="客户鞋型" width="90"></el-table-column>
-                <el-table-column prop="status" label="状态"></el-table-column>
+                <el-table-column prop="orderStartDate" label="订单开始"></el-table-column>
+                <el-table-column prop="orderEndDate" label="出货日期"></el-table-column>
+                <el-table-column prop="shoeRId" label="工厂型号"></el-table-column>
+                <el-table-column prop="customerProductName" label="客户鞋型"></el-table-column>
+                <el-table-column prop="status" label="生产状态"></el-table-column>
                 <el-table-column prop="orderShoeTotal" label="数量"></el-table-column>
                 <el-table-column label="车间生产进度" header-align="center">
                     <el-table-column prop="totalCuttingAmount" label="裁断"></el-table-column>
@@ -60,9 +47,9 @@
                     <el-table-column prop="totalSewingAmount" label="针车"></el-table-column>
                     <el-table-column prop="totalMoldingAmount" label="成型"></el-table-column>
                 </el-table-column>
-                <el-table-column label="排产">
+                <el-table-column label="生产信息">
                     <template #default="scope">
-                        <el-button type="primary" size="small" @click="openScheduleDialog(scope.row)">
+                        <el-button type="primary" size="small" @click="openProdDetailDialog(scope.row)">
                             查看
                         </el-button>
                     </template>
@@ -71,196 +58,12 @@
         </el-col>
     </el-row>
     <el-row :gutter="20">
-        <el-col :span="12" :offset="14">
+        <el-col>
             <el-pagination @size-change="handleSizeChange" @current-change="handlePageChange"
-                :current-page="currentPage" :page-sizes="[10, 20, 30, 40]" :page-size="pageSize"
+                :current-page="currentPage" :page-size="pageSize"
                 layout="total, sizes, prev, pager, next, jumper" :total="orderTotalRows" />
         </el-col>
     </el-row>
-
-    <el-dialog title="多鞋型排产页面" v-model="isMultipleShoesDialogVis" width="50%">
-        <el-row :gutter="20">
-            已选中鞋型：{{ displaySelectedOrderShoe() }}
-        </el-row>
-        <el-form :model="multipleShoesScheduleForm" :rules="rules" ref="multipleShoesScheduleForm" class="custom-form">
-            <!-- <el-form-item label="裁断线号选择" prop="cuttingLineNumbers">
-                <el-select v-model="multipleShoesScheduleForm.cuttingLineNumbers" placeholder="" multiple>
-                    <el-option v-for="item in productionLines['cutting']" :key="item" :label="item" :value="item">
-                    </el-option>
-                </el-select>
-            </el-form-item> -->
-            <el-form-item label="裁断生产周期" prop="cuttingDateRange">
-                <el-date-picker v-model="multipleShoesScheduleForm.cuttingDateRange" type="daterange" size="default"
-                    range-separator="至" value-format="YYYY-MM-DD">
-                </el-date-picker>
-            </el-form-item>
-            <!-- <el-form-item label="针车预备线号选择" prop="preSewingLineNumbers">
-                <el-select v-model="multipleShoesScheduleForm.preSewingLineNumbers" placeholder="" @change="" multiple>
-                    <el-option v-for="item in productionLines['preSewing']" :key="item" :label="item" :value="item">
-                    </el-option>
-                </el-select>
-            </el-form-item> -->
-            <el-form-item label="针车预备生产周期" prop="preSewingDateRange">
-                <el-date-picker v-model="multipleShoesScheduleForm.preSewingDateRange" type="daterange" size="default"
-                    range-separator="至" value-format="YYYY-MM-DD">
-                </el-date-picker>
-            </el-form-item>
-            <!-- <el-form-item label="针车线号选择" prop="sewingLineNumbers">
-                <el-select v-model="multipleShoesScheduleForm.sewingLineNumbers" placeholder="" @change="" multiple>
-                    <el-option v-for="item in productionLines['sewing']" :key="item" :label="item" :value="item">
-                    </el-option>
-                </el-select>
-            </el-form-item> -->
-            <el-form-item label="针车生产周期" prop="sewingDateRange">
-                <el-date-picker v-model="multipleShoesScheduleForm.sewingDateRange" type="daterange" size="default"
-                    range-separator="至" value-format="YYYY-MM-DD">
-                </el-date-picker>
-            </el-form-item>
-            <!-- <el-form-item label="成型线号选择" prop="moldingLineNumbers">
-                <el-select v-model="multipleShoesScheduleForm.moldingLineNumbers" placeholder="" @change="" multiple>
-                    <el-option v-for="item in productionLines['molding']" :key="item" :label="item" :value="item">
-                    </el-option>
-                </el-select>
-            </el-form-item> -->
-            <el-form-item label="成型生产周期" prop="moldingDateRange">
-                <el-date-picker v-model="multipleShoesScheduleForm.moldingDateRange" type="daterange" size="default"
-                    range-separator="至" value-format="YYYY-MM-DD">
-                </el-date-picker>
-            </el-form-item>
-        </el-form>
-        <template #footer>
-            <span>
-                <el-button type="primary" @click="isMultipleShoesDialogVis = false">返回</el-button>
-                <el-button type="primary" @click="saveMultipleSchedules">保存</el-button>
-            </span>
-        </template>
-    </el-dialog>
-
-    <el-dialog :title="`订单${currentRow.orderRId}-鞋型${currentRow.shoeRId}排产信息`" v-model="isScheduleDialogOpen"
-        fullscreen>
-        <el-tabs v-model="activeTab" tab-position="top" @tab-click="">
-            <el-tab-pane v-for="tab in tabs" :key="tab.name" :label="tab.label" :name="tab.name">
-                <el-row :gutter="20">
-                    <el-col :span="4" v-for="subTab in tabs">
-                        {{ `${subTab.dateLabel}: ${subTab.dateValue[0] ? subTab.dateValue[0] + '至' + subTab.dateValue[1]
-                            :
-                            '未设置'}` }}
-                    </el-col>
-
-                </el-row>
-                <el-row :gutter="20">
-                    <el-col :span="10" :offset="0">
-                        <span>
-                            {{ tab.dateLabel }}：
-                            <el-date-picker v-model="tab.dateValue" type="daterange" size="default" range-separator="-"
-                                value-format="YYYY-MM-DD" :readonly="!(role == 6)">
-                            </el-date-picker>
-                        </span>
-                        <el-button type="primary" size="default" @click="checkDateProductionStatus(tab)">{{
-                            tab.isDateStatusTableVis ? '关闭表格' : '查看工期内排产情况' }}</el-button>
-                    </el-col>
-                    <el-col :span="8" :offset="6">
-                        <el-descriptions title="" border v-if="role == 6">
-                            <el-descriptions-item label="外包状态">
-                                <div v-if="tab.isOutsourced == 0">
-                                    未设置外包
-                                </div>
-                                <div v-else>
-                                    已设置外包
-                                </div>
-                            </el-descriptions-item>
-                            <el-descriptions-item label="操作">
-                                <el-button v-if="tab.isOutsourced == 0" type="primary" size="default"
-                                    @click="openOutsourceFlow()">启动外包流程</el-button>
-                                <el-button-group v-else>
-                                    <el-button type="primary" size="default"
-                                        @click="openOutsourceFlow()">查看外包流程</el-button>
-                                </el-button-group>
-                            </el-descriptions-item>
-                        </el-descriptions>
-                    </el-col>
-                </el-row>
-                <el-row :gutter="20">
-                    <el-table v-if="tab.isDateStatusTableVis" :data="tab.dateStatusTable" border stripe read>
-                        <el-table-column type="expand">
-                            <template #default="props">
-                                <el-table :data="props.row.detail" border stripe>
-                                    <el-table-column type="index" />
-                                    <el-table-column label="订单号" prop="orderRId" />
-                                    <el-table-column label="工厂型号" prop="shoeRId" />
-                                    <el-table-column label="鞋型总数量" prop="totalAmount" />
-                                    <el-table-column label="工段生产开始" prop="productionStartDate" />
-                                    <el-table-column label="工段生产结束" prop="productionEndDate" />
-                                    <el-table-column label="平均每天数量" prop="averageAmount" />
-                                </el-table>
-                            </template>
-                        </el-table-column>
-
-                        <el-table-column prop="date" label="日期"> </el-table-column>
-                        <el-table-column prop="orderShoeCount" label="已排产鞋型数"> </el-table-column>
-                        <el-table-column prop="predictAmount" label="预计当日现有生产量"> </el-table-column>
-                    </el-table>
-                </el-row>
-                <el-row>
-                    计划自产数量
-                </el-row>
-                <el-row :gutter="20">
-                    <el-col>
-                        <el-table v-loading="isLoading" :data="tab.productionAmountTable" border stripe
-                            :max-height="500">
-                            <el-table-column prop="colorName" label="颜色"></el-table-column>
-                            <el-table-column prop="totalAmount" label="颜色总数"></el-table-column>
-                            <!-- <el-table-column prop="" label="已设置外包数量"></el-table-column> -->
-                            <el-table-column v-for="column in filteredColumns" :key="column.prop" :prop="column.prop"
-                                :label="column.label">
-                                <template v-slot="scope">
-                                    <el-input-number v-model="scope.row[column.prop]"
-                                        v-if="(currentRow.status === '未排期' || currentRow.status === '已保存排期') && role == 6"
-                                        :min="0" :step="1" />
-                                    <span v-else>{{ scope.row[column.prop] }}</span>
-                                </template>
-                            </el-table-column>
-                        </el-table>
-                    </el-col>
-                </el-row>
-            </el-tab-pane>
-        </el-tabs>
-        <el-row :gutter="20" style="margin-top: 20px">
-            <el-col :span="24" :offset="0">
-                订单数量
-                <el-table v-loading="isLoading" :data="shoeBatchInfo" :span-method="spanMethod" border stripe
-                    :max-height="500">
-                    <el-table-column prop="colorName" label="颜色"></el-table-column>
-                    <el-table-column prop="totalAmount" label="颜色总数"></el-table-column>
-                    <el-table-column v-for="column in filteredColumns" :key="column.prop" :prop="column.prop"
-                        :label="column.label"></el-table-column>
-                </el-table>
-            </el-col>
-        </el-row>
-        <el-row :gutter="20" style="margin-top: 20px">
-            <el-col :span="24" :offset="0">
-                商务部工艺备注
-                <el-input v-model="currentRow.technicalRemark" autosize type="textarea" readonly />
-            </el-col>
-        </el-row>
-        <el-row :gutter="20" style="margin-top: 20px">
-            <el-col :span="24" :offset="0">
-                商务部材料备注
-                <el-input v-model="currentRow.materialRemark" autosize type="textarea" readonly />
-            </el-col>
-        </el-row>
-        <template #footer>
-            <span>
-                <el-button @click="isScheduleDialogOpen = false">取消</el-button>
-                <el-button type="primary" @click="openProdDetailDialog(this.currentRow)">查看生产信息</el-button>
-                <el-button v-if="role == 6"
-                    type="primary" @click="modifyProductionSchedule">保存排期</el-button>
-                <el-button v-if="(currentRow.status === '未排期' || currentRow.status === '已保存排期') && role == 6"
-                    type="success" @click="startProduction">下发排期</el-button>
-            </span>
-        </template>
-    </el-dialog>
-
     <el-dialog title="生产信息一览" v-model="isProdDetailDialogOpen" fullscreen @close="onDialogClose">
         <el-tabs v-model="currentProdDetailTab" tab-position="top">
             <el-tab-pane name="1" label="物料">
@@ -325,7 +128,6 @@ export default {
     },
     data() {
         return {
-            isSearchDialogVisible: false,
             customerNameOptions: [],
             searchForm: {
                 orderDateRangeSearch: null,
@@ -335,16 +137,11 @@ export default {
                 statusNodeSearch: null,
                 customerNameSearch: null,
                 customerBrandSearch: null,
-                sortCondition: null
+                sortCondition: null,
+                mode: false
             },
             currentProdDetailTab: "1",
             isProdDetailDialogOpen: false,
-            showFilters: false,
-            filters: [
-                { label: 'Name', value: '', key: 'name' },
-                { label: 'Age', value: '', key: 'age' },
-                // Add more filters here
-            ],
             isPriceReportDialogOpen: false,
             currentPriceReportTab: 0,
             reportPanes: [
@@ -366,7 +163,6 @@ export default {
                 }
             ],
             role: localStorage.getItem('role'),
-
             getShoeSizesName,
             currentPage: 1,
             pageSize: 10,
@@ -375,29 +171,10 @@ export default {
             currentRow: {},
             shoeBatchInfo: [],
             spanMethod: null,
-            logisticsMaterialData: [],
-            logisticsRows: 0,
-            isMaterialLogisticVis: false,
-            logisticsCurrentPage: 1,
-            logisticsPageSize: 10,
-            instruction: false,
-            specification: false,
             isMultipleSelection: false,
             selectedRows: [],
             isMultipleShoesDialogVis: false,
             multipleShoesScheduleForm: {},
-            multiShoeFormTemplate: {
-                cuttingLineNumbers: null,
-                cuttingDateRange: null,
-                preSewingLineNumbers: null,
-                preSewingDateRange: null,
-                sewingLineNumbers: null,
-                sewingDateRange: null,
-                moldingLineNumbers: null,
-                moldingDateRange: null,
-            },
-            // productionLines,
-            shoeSizes: [],
             isScheduleDialogOpen: false,
             shoeSizeColumns: [],
             activeTab: "cutting",
@@ -500,27 +277,14 @@ export default {
         this.getAllCustomers()
         await this.getOrderDataTable()
     },
-    computed: {
-        filteredColumns() {
-            return this.shoeSizeColumns.filter(column =>
-                this.shoeBatchInfo.some(row => row[column.prop] !== undefined && row[column.prop] !== null && row[column.prop] !== 0)
-            );
-        }
-    },
     methods: {
         async getAllCustomers() {
             const response = await axios.get(`${this.$apiBaseUrl}/customer/getallcustomers`)
             this.customerNameOptions = response.data
         },
-        updateDialogVisible(newVal) {
-            this.isSearchDialogVisible = newVal
-        },
         handleSearch(values) {
             this.searchForm = { ...values }
             this.getOrderDataTable()
-        },
-        toggleFilters() {
-            this.showFilters = !this.showFilters;
         },
         openProdDetailDialog(row) {
             this.currentRow = row
@@ -542,230 +306,13 @@ export default {
             }
             this.isPriceReportDialogOpen = true
         },
-        async checkDateProductionStatus(tab) {
-            if (tab.isDateStatusTableVis === true) {
-                tab.isDateStatusTableVis = false
-            }
-            else {
-                const params = { "startDate": tab.dateValue[0], "endDate": tab.dateValue[1], "team": tab.name }
-                try {
-                    const response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/checkdateproductionstatus`, { params })
-                    tab.dateStatusTable = response.data
-                    tab.dateStatusTable.forEach(element => {
-                        let amount = 0
-                        element.detail.forEach(row => {
-                            row.averageAmount = this.calculateDailyProduction(row.totalAmount, [row.productionStartDate, row.productionEndDate])
-                            amount += Number(row.averageAmount)
-                        })
-                        element.predictAmount = amount;
-                        tab.isDateStatusTableVis = true
-                    })
-                }
-                catch (error) {
-                    ElMessage.error(error.response.data.message)
-                }
-            }
-        },
-        calculateDailyProduction(totalShoes, dateRange) {
-            if (dateRange && dateRange.length === 2) {
-                const startDate = new Date(dateRange[0]);
-                const endDate = new Date(dateRange[1]);
-                const timeDiff = Math.abs(endDate - startDate);
-                const diffDays = Math.ceil(timeDiff / (1000 * 60 * 60 * 24)) + 1;
-                return (Number(totalShoes) / diffDays).toFixed(2);
-            }
-            return 0;
-        },
-        openOutsourceFlow() {
-            const params = {
-                "orderId": this.currentRow.orderId,
-                "orderRId": this.currentRow.orderRId,
-                "orderShoeId": this.currentRow.orderShoeId,
-                "shoeRId": this.currentRow.shoeRId,
-            }
-            const queryString = new URLSearchParams(params).toString();
-            const url = `${window.location.origin}/productiongeneral/productionoutsource?${queryString}`
-            window.open(url, '_blank')
-        },
-        async openScheduleDialog(row) {
-            this.isLoading = true
-            this.currentRow = row
-            this.isScheduleDialogOpen = true
-            this.shoeSizeColumns = await this.getShoeSizesName(row.orderId)
-            this.tabs = JSON.parse(JSON.stringify(this.tabsTemplate))
-            this.getOrderShoeScheduleInfo()
-            await this.getOrderShoeBatchInfo()
-            await this.getOutsourceAmount()
-            await this.getOrderShoeProductionAmount()
-            this.isLoading = false
-        },
-        async getOrderShoeScheduleInfo() {
-            let params = { "orderShoeId": this.currentRow.orderShoeId }
-            let response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getordershoescheduleinfo`, { params })
-            response.data.forEach((row, index) => {
-                this.tabs[index].lineValue = row.lineGroup
-                this.tabs[index].dateValue = [row.startDate, row.endDate]
-                this.tabs[index].isOutsourced = row.isOutsourced
-            })
-        },
-        async getOutsourceAmount() {
-            let params = { "orderShoeId": this.currentRow.orderShoeId }
-            let response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getoutsourcebatchinfo`, { params })
-            console.log(response.data)
-        },
-        async getOrderShoeBatchInfo() {
-            this.shoeBatchInfo = []
-            const params = { "orderShoeId": this.currentRow.orderShoeId }
-            const response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getordershoetypeamount`, { params })
-            this.shoeBatchInfo = response.data
-            console.log(this.shoeBatchInfo)
-            this.spanMethod = shoeBatchInfoTableSpanMethod(this.shoeBatchInfo);
-        },
-        async getOrderShoeProductionAmount() {
-            const params = { "orderShoeId": this.currentRow.orderShoeId }
-            const response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getordershoeproductionamount`, { params })
-            this.tabs.forEach(row => {
-                if (response.data[row.team] === undefined) {
-                    row.productionAmountTable = []
-                    let color_totals = {}
-                    this.shoeBatchInfo.forEach(batchInfo => {
-                        if (!(batchInfo.colorName in color_totals)) {
-                            color_totals[batchInfo.colorName] = { ...batchInfo }
-                        }
-                        else {
-                            for (let i = 34; i < 47; i++) {
-                                color_totals[batchInfo.colorName][`size${i}Amount`] += batchInfo[`size${i}Amount`]
-                            }
-                            color_totals[batchInfo.colorName][`pairAmount`] += batchInfo[`pairAmount`]
-                        }
-                    })
-                    for (let color_key in color_totals) {
-                        row.productionAmountTable.push(color_totals[color_key])
-                    }
-                }
-                else {
-                    row.productionAmountTable = response.data[row.team]
-                }
-                // row.productionSpanMethod = shoeBatchInfoTableSpanMethod(row.productionAmountTable)
-            })
-            this.tabs[1].productionAmountTable = this.tabs[2].productionAmountTable
-        },
-        displaySelectedOrderShoe() {
-            let uniqueData = this.selectedRows.filter((item, index, self) =>
-                index === self.findIndex((t) => (
-                    t.orderShoeId === item.orderShoeId
-                ))
-            )
-            uniqueData = uniqueData.map(item => `(订单号: ${item.orderRId}, 鞋型号: ${item.shoeRId})`).join(', ');
-            return uniqueData.toString()
-        },
-        async saveMultipleSchedules() {
-            this.$refs.multipleShoesScheduleForm.validate(async (valid) => {
-                if (valid) {
-                    try {
-                        console.log(this.multipleShoesScheduleForm)
-                        let data = {
-                            "orderShoeIdArr": this.selectedRows.map(row => row.orderShoeId),
-                            "scheduleForm": this.multipleShoesScheduleForm
-                        }
-                        await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/savemultipleschedules`, data)
-                        ElMessage.success("保存成功")
-                    }
-                    catch (error) {
-                        ElMessage.error(error)
-                    }
-                    this.getOrderDataTable()
-                    this.isMultipleShoesDialogVis = false
-                }
-                else {
-                    console.log("testing2")
-                }
-            })
-        },
-        async modifyProductionSchedule() {
-            try {
-                let data = {
-                    "orderShoeId": this.currentRow.orderShoeId,
-                }
-                let infoList = []
-                this.tabs.forEach(row => {
-                    let obj = {
-                        "lineValue": row.lineValue.join(","),
-                        "isOutsourced": row.isOutsourced,
-                        "startDate": row.dateValue[0],
-                        "endDate": row.dateValue[1]
-                    }
-                    infoList.push(obj)
-                })
-                data["productionInfoList"] = infoList
-                await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/editproductionschedule`, data)
-                let temp_data = [this.tabs[0].productionAmountTable, this.tabs[2].productionAmountTable, this.tabs[3].productionAmountTable]
-                data = []
-                temp_data.forEach((table, index) => {
-                    table.forEach(row => {
-                        let obj = {
-                            "productionAmountId": row.productionAmountId,
-                            "orderShoeTypeId": row.orderShoeTypeId,
-                            "productionTeam": index,
-                        }
-                        for (let i = 34; i < 47; i++) {
-                            obj[`size${i}Amount`] = row[`size${i}Amount`]
-                        }
-                        data.push(obj)
-                    })
-                })
-                await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/saveproductionamount`, data)
-                ElMessage.success("修改成功")
-            }
-            catch (error) {
-                ElMessage.error("修改失败")
-            }
-            this.getOrderDataTable()
-            this.isScheduleDialogOpen = false
-        },
-        async startProduction() {
-            ElMessageBox.alert('请确认生产数量和外包数量', '警告', {
-                confirmButtonText: '确认',
-                showCancelButton: true,
-                cancelButtonText: '取消'
-            }).then(async () => {
-                try {
-                    await this.modifyProductionSchedule()
-                    const data = { "orderId": this.currentRow.orderId, "orderShoeId": this.currentRow.orderShoeId }
-                    await axios.patch(`${this.$apiBaseUrl}/production/productionmanager/startproduction`, data)
-                    ElMessage.success("操作成功")
-                }
-                catch (error) {
-                    console.log(error)
-                    ElMessage.error("操作失败")
-                }
-                this.getOrderDataTable()
-                this.isScheduleDialogOpen = false
-            })
-        },
-        openMultipleShoesDialog() {
-            if (this.selectedRows.length == 0) {
-                this.isSelectedRowsEmpty = true
-                return
-            }
-            this.multipleShoesScheduleForm = { ...this.multiShoeFormTemplate }
-            this.isMultipleShoesDialogVis = true
-            this.isSelectedRowsEmpty = false
-        },
-        toggleSelectionMode() {
-            this.isMultipleSelection = !this.isMultipleSelection;
-            this.isSelectedRowsEmpty = false
-        },
-        handleSelectionChange(selection) {
-            this.selectedRows = selection
-        },
         async handlePageChange(val) {
             this.currentPage = val
-            await this.getOrderDataTable()
+            this.getOrderDataTable()
         },
         async handleSizeChange(val) {
             this.pageSize = val
-            await this.getOrderDataTable()
+            this.getOrderDataTable()
         },
         downloadPackagingInfo() {
             window.open(
@@ -794,9 +341,10 @@ export default {
                 "customerBrand": this.searchForm.customerBrandSearch,
                 "orderStartDate": startDate,
                 "orderEndDate": endDate,
-                "sortCondition": this.searchForm.sortCondition
+                "sortCondition": this.searchForm.sortCondition,
+                "mode": this.searchForm.mode
             }
-            let response = await axios.get(`${this.$apiBaseUrl}/production/productionmanager/getallorderproductionprogress`, { params })
+            let response = await axios.get(`${this.$apiBaseUrl}/production/getallorderproductionprogress`, { params })
             this.orderTableData = response.data.result
             this.orderTotalRows = response.data.totalLength
         },

--- a/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionSharedPages/OrderSchedulingSearchDialog.vue
+++ b/frontend/jiancheng/src/Pages/ProductionManagementDepartment/ProductionSharedPages/OrderSchedulingSearchDialog.vue
@@ -1,31 +1,19 @@
 <template>
     <el-form :inline="true">
-        <el-form-item label="客户名称">
-            <el-select v-model="localSearchForm.customerNameSearch" value-key="" placeholder="例：37" clearable filterable
-                @change="handleConfirm">
-                <el-option v-for="item in customerNameOptions" :value="item" :label="item" />
-            </el-select>
-        </el-form-item>
-        <el-form-item label="客户商标">
-            <el-input v-model="localSearchForm.customerBrandSearch" placeholder="例：CLOWSE" @change="handleConfirm" clearable />
-        </el-form-item>
         <el-form-item label="订单号">
             <el-input v-model="localSearchForm.orderRIdSearch" placeholder="例：K24-001" @change="handleConfirm" clearable />
         </el-form-item>
         <el-form-item label="工厂型号">
             <el-input v-model="localSearchForm.shoeRIdSearch" placeholder="例：3E1122" @change="handleConfirm" clearable />
         </el-form-item>
-        <el-form-item label="客户型号">
-            <el-input v-model="localSearchForm.customerProductNameSearch" placeholder="例：CL-B001" @change="handleConfirm" clearable />
-        </el-form-item>
         <el-form-item label="状态点">
-            <el-select v-model="localSearchForm.statusNodeSearch" placeholder="例：生产中" @change="handleConfirm" clearable style="width: 150px;">
+            <el-select v-model="localSearchForm.statusNodeSearch" placeholder="例：裁断未排期" @change="handleConfirm" clearable style="width: 150px;">
                 <el-option v-for="item in [
-                    '未排期',
-                    '已保存排期',
-                    '生产前确认',
-                    '生产中',
-                    '生产结束',
+                    '裁断未排期',
+                    '预备未排期',
+                    '针车未排期',
+                    '成型未排期',
+                    '已排期',
                 ]" :key="item" :label="item" :value="item">
                 </el-option>
             </el-select>
@@ -46,21 +34,11 @@
                 </el-option>
             </el-select>
         </el-form-item>
-        <el-form-item label="显示订单模式">
-            <el-switch v-model="localSearchForm.mode" inactive-text="进行中的订单" active-text="所有订单" @change="handleConfirm"></el-switch>
-        </el-form-item>
     </el-form>
 </template>
 <script>
-import axios from 'axios'
-import { markRaw } from 'vue'
-import { Search } from '@element-plus/icons-vue'
 export default {
     props: {
-        customerNameOptions: {
-            type: Array,
-            required: true,
-        },
         searchForm: {
             type: Object,
             required: true


### PR DESCRIPTION
1. 排期代码从进度部分分离
2. model.py添加scheduling status方便查询排期状态
3. 进度页面根据当天日期和安排日期比较显示”预计生产状态“

进度页面：
![image](https://github.com/user-attachments/assets/c1985f14-9788-4518-89cb-0696bdcfcf29)

排期主页面：
![image](https://github.com/user-attachments/assets/ee41dafa-3054-40f1-ba41-e2387249a678)

排期dialog （未完成前序排期无法排期后序）:
![image](https://github.com/user-attachments/assets/865fa8ad-a4b6-4719-be7d-04f0f6b6a2c7)
