### PR TITLE
update order status display in logistic flow 

### DIFF
--- a/frontend/jiancheng/src/Pages/DevelopmentManager/views/ProductionOrderCreateView.vue
+++ b/frontend/jiancheng/src/Pages/DevelopmentManager/views/ProductionOrderCreateView.vue
@@ -23,6 +23,18 @@
                                 <el-descriptions-item label="客户名称" align="center">{{ orderData.customerName }}</el-descriptions-item>
                                 <el-descriptions-item label="订单预计截止日期" align="center">{{ orderData.deadlineTime }}</el-descriptions-item>
                                 <el-descriptions-item label="商标" align="center">{{ orderData.customerBrand }}</el-descriptions-item>
+                                <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                                    orderData.currentOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                                    orderData.previousOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序下发时间" align="center">{{
+                                    orderData.previousOrderShoeStatusTime
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="迟滞时间" align="center">{{
+                                    orderData.delayTime
+                                    }}</el-descriptions-item>
                             </el-descriptions>
                         </el-col>
                     </el-row>
@@ -2070,7 +2082,7 @@ export default {
             this.materialNameOptions = response.data
         },
         async getOrderInfo() {
-            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}`)
+            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}&status=0`)
             this.orderData = response.data
             console.log(this.orderData)
             this.updateArrowKey += 1

--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/FirstOrderBOMView.vue
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/FirstOrderBOMView.vue
@@ -52,6 +52,18 @@
                         <el-descriptions-item label="尺码数量对照表" align="center">
                             <el-button type="primary" size="default" @click="openSizeComparisonDialog">查看</el-button>
                         </el-descriptions-item>
+                        <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                            orderData.currentOrderShoeStatus
+                            }}</el-descriptions-item>
+                        <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                            orderData.previousOrderShoeStatus
+                            }}</el-descriptions-item>
+                        <el-descriptions-item label="前序下发时间" align="center">{{
+                            orderData.previousOrderShoeStatusTime
+                            }}</el-descriptions-item>
+                        <el-descriptions-item label="迟滞时间" align="center">{{
+                            orderData.delayTime
+                            }}</el-descriptions-item>
                         <el-descriptions-item label="退回订单" align="center">
                             <el-button type="danger" size="default" @click="openReturnOrderDialog">退回流程</el-button>
                         </el-descriptions-item>
@@ -935,7 +947,7 @@ export default {
         },
         async getOrderInfo() {
             const response = await axios.get(
-                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}`
+                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}&status=6`
             )
             this.orderData = response.data
         },

--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/SecondOrderBOMView.vue
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/SecondOrderBOMView.vue
@@ -52,6 +52,18 @@
                         <el-descriptions-item label="尺码数量对照表" align="center">
                             <el-button type="primary" size="default" @click="openSizeComparisonDialog">查看</el-button>
                         </el-descriptions-item>
+                        <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                            orderData.currentOrderShoeStatus
+                            }}</el-descriptions-item>
+                        <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                            orderData.previousOrderShoeStatus
+                            }}</el-descriptions-item>
+                        <el-descriptions-item label="前序下发时间" align="center">{{
+                            orderData.previousOrderShoeStatusTime
+                            }}</el-descriptions-item>
+                        <el-descriptions-item label="迟滞时间" align="center">{{
+                            orderData.delayTime
+                            }}</el-descriptions-item>
                         <el-descriptions-item label="退回订单" align="center">
                             <el-button type="danger" size="default" @click="openReturnOrderDialog">退回流程</el-button>
                         </el-descriptions-item>
@@ -926,7 +938,7 @@ export default {
         },
         async getOrderInfo() {
             const response = await axios.get(
-                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}`
+                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}&status=7`
             )
             this.orderData = response.data
         },

--- a/frontend/jiancheng/src/Pages/TechnologyDepartment/TechnicalManager/views/AdjustUpload.vue
+++ b/frontend/jiancheng/src/Pages/TechnologyDepartment/TechnicalManager/views/AdjustUpload.vue
@@ -25,6 +25,18 @@
                                 <el-descriptions-item label="前序处理部门">{{ testOrderData.prevDepart }}</el-descriptions-item>
                                 <el-descriptions-item label="前序处理人">{{ testOrderData.prevUser }}</el-descriptions-item> -->
                                 <el-descriptions-item label="订单预计截止日期" align="center">{{ orderData.deadlineTime }}</el-descriptions-item>
+                                <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                                    orderData.currentOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                                    orderData.previousOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序下发时间" align="center">{{
+                                    orderData.previousOrderShoeStatusTime
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="迟滞时间" align="center">{{
+                                    orderData.delayTime
+                                    }}</el-descriptions-item>
                                 <el-descriptions-item label="退回订单" align="center">
                                     <el-button type="danger" size="default" @click="openReturnOrderDialog">退回流程</el-button>
                                 </el-descriptions-item>
@@ -1478,7 +1490,7 @@ export default {
             this.assetFilterTable = this.assetTable
         },
         async getOrderInfo() {
-            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}`)
+            const response = await axios.get(`${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}&status=9`)
             this.orderData = response.data
             console.log(this.orderData)
             this.updateArrowKey += 1

--- a/frontend/jiancheng/src/Pages/TechnologyDepartment/TechnicalManager/views/BOMReview.vue
+++ b/frontend/jiancheng/src/Pages/TechnologyDepartment/TechnicalManager/views/BOMReview.vue
@@ -33,6 +33,18 @@
                                 <el-descriptions-item label="订单预计截止日期" align="center">{{
                                     orderData.deadlineTime
                                     }}</el-descriptions-item>
+                                <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                                    orderData.currentOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                                    orderData.previousOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序下发时间" align="center">{{
+                                    orderData.previousOrderShoeStatusTime
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="迟滞时间" align="center">{{
+                                    orderData.delayTime
+                                    }}</el-descriptions-item>
                                 <el-descriptions-item label="退回订单" align="center">
                                     <el-button type="danger" size="default"
                                         @click="openReturnOrderDialog">退回流程</el-button>
@@ -511,7 +523,7 @@ export default {
         },
         async getOrderInfo() {
             const response = await axios.get(
-                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}`
+                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}&status=13`
             )
             this.orderData = response.data
             console.log(this.orderData)

--- a/frontend/jiancheng/src/Pages/UsageCalculation/views/SecondBOMCreateView.vue
+++ b/frontend/jiancheng/src/Pages/UsageCalculation/views/SecondBOMCreateView.vue
@@ -30,6 +30,18 @@
                                 <el-descriptions-item label="订单预计截止日期" align="center">{{
                                     orderData.deadlineTime
                                     }}</el-descriptions-item>
+                                <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                                    orderData.currentOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                                    orderData.previousOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序下发时间" align="center">{{
+                                    orderData.previousOrderShoeStatusTime
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="迟滞时间" align="center">{{
+                                    orderData.delayTime
+                                    }}</el-descriptions-item>
                                 <el-descriptions-item label="退回订单" align="center">
                                     <el-button type="danger" size="default"
                                         @click="openReturnOrderDialog">退回流程</el-button>
@@ -693,7 +705,7 @@ export default {
         },
         async getOrderInfo() {
             const response = await axios.get(
-                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}`
+                `${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.orderId}&status=11`
             )
             this.orderData = response.data
             console.log(this.orderData)

--- a/frontend/jiancheng/src/Pages/UsageCalculation/views/UsageCalculationInput.vue
+++ b/frontend/jiancheng/src/Pages/UsageCalculation/views/UsageCalculationInput.vue
@@ -22,6 +22,18 @@
                                 <el-descriptions-item label="订单创建时间" align="center">{{ orderData.createTime }}</el-descriptions-item>
                                 <el-descriptions-item label="客户名称" align="center">{{ orderData.customerName }}</el-descriptions-item>
                                 <el-descriptions-item label="订单预计截止日期" align="center">{{ orderData.deadlineTime }}</el-descriptions-item>
+                                <el-descriptions-item label="订单鞋型当前状态" align="center">{{
+                                    orderData.currentOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序订单鞋型状态" align="center">{{
+                                    orderData.previousOrderShoeStatus
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="前序下发时间" align="center">{{
+                                    orderData.previousOrderShoeStatusTime
+                                    }}</el-descriptions-item>
+                                <el-descriptions-item label="迟滞时间" align="center">{{
+                                    orderData.delayTime
+                                    }}</el-descriptions-item>
                                 <el-descriptions-item label="退回订单" align="center">
                                     <el-button type="danger" size="default" @click="openReturnOrderDialog">退回流程</el-button>
                                 </el-descriptions-item>
@@ -467,7 +479,7 @@ export default {
             this.assetFilterTable = this.assetTable
         },
         async getOrderInfo() {
-            const response = await this.$axios.get(`${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.$props.orderId}`)
+            const response = await this.$axios.get(`${this.$apiBaseUrl}/order/getorderInfo?orderid=${this.$props.orderId}&status=4`)
             this.orderData = response.data
             console.log(this.orderData)
             this.updateArrowKey += 1


### PR DESCRIPTION
为所有物控流程页面添加前序名称，当前流转状态，前序下发时间，迟滞时间显示
<img width="1920" height="1032" alt="图片" src="https://github.com/user-attachments/assets/ec99e3b7-e5a6-4b0d-8def-88f80dde1aec" />
