### PR TITLE
add dbclick event in order management

### DIFF
--- a/frontend/jiancheng/src/Pages/BusinessManager/components/OrderManagement.vue
+++ b/frontend/jiancheng/src/Pages/BusinessManager/components/OrderManagement.vue
@@ -73,7 +73,7 @@
         </el-col> -->
     </el-row>
     <el-row :gutter="20">
-        <el-table :data="paginatedDisplayData" border stripe height="500">
+        <el-table :data="paginatedDisplayData" border stripe height="500" @row-dblclick="orderRowDbClick">
             <el-table-column prop="orderRid" label="订单号" sortable />
             <el-table-column prop="orderSalesman" label="创建业务员" />
             <el-table-column prop="orderSupervisor" label="审核" />
@@ -2048,6 +2048,9 @@ export default {
                         message: '已取消删除'
                     })
                 })
+        },
+        orderRowDbClick(row) {
+            this.openOrderDetail(row.orderDbId)
         },
     },
     watch: {


### PR DESCRIPTION
针对业务提出的不方便单击按钮的问题，加入订单表格的双击事件，同样可以触发打开详情页