### PR TITLE
add purchase order info to warehouse/logistic main page

### DIFF
--- a/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/LogisticsControlManager.vue
+++ b/frontend/jiancheng/src/Pages/LogisticsControlDepartment/LogisticsControlManager/views/LogisticsControlManager.vue
@@ -37,6 +37,9 @@
                         <el-menu-item index="12" @click="handleMenuClick(12)">
                             <span>入/出库记录</span>
                         </el-menu-item>
+                        <el-menu-item index="13" @click="handleMenuClick(13)">
+                            <span>采购订单信息</span>
+                        </el-menu-item>
                         <el-menu-item index="6" @click="handleMenuClick(6)">
                             <span>仓库管理</span>
                         </el-menu-item>
@@ -84,6 +87,7 @@ import TestPage from '../components/TestPage.vue'
 import MaterialStorage from '@/Pages/TotalWarehouse/HeadOfWarehouse/components/MaterialStorage.vue'
 import { UserFilled } from '@element-plus/icons-vue'
 import FinancialWarehouseDetail from '@/Pages/FinancialManager/components/FinancialWarehouseDetail.vue'
+import PurchaseOrderInfo from '@/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseOrderInfo.vue'
 export default {
     components: {
         AllHeader,
@@ -101,7 +105,8 @@ export default {
         MultiPurchaseIssue,
         RevertDashboard,
         MaterialStorage,
-        FinancialWarehouseDetail
+        FinancialWarehouseDetail,
+        PurchaseOrderInfo
     },
     data() {
         return {
@@ -156,6 +161,8 @@ export default {
                 case 12:
                     this.currentComponent = 'FinancialWarehouseDetail'
                     break
+                case 13:
+                    this.currentComponent = 'PurchaseOrderInfo'
             }
         },
         async logout() {

--- a/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseOrderInfo.vue
+++ b/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/components/PurchaseOrderInfo.vue
@@ -38,6 +38,8 @@
                 <el-table-column prop="materialColor" label="颜色"></el-table-column>
                 <el-table-column prop="materialUnit" label="单位"></el-table-column>
                 <el-table-column prop="purchaseAmount" label="采购数量"></el-table-column>
+                <el-table-column prop="inboundAmount" label="已入库数量"></el-table-column>
+                <el-table-column prop="currentAmount" label="当前数量"></el-table-column>
             </el-table>
     </el-row>
     <el-row :gutter="20">

--- a/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/views/HeadOfWarehouse.vue
+++ b/frontend/jiancheng/src/Pages/TotalWarehouse/HeadOfWarehouse/views/HeadOfWarehouse.vue
@@ -34,6 +34,9 @@
                         <el-menu-item index="16" @click="handleMenuClick(16)">
                             <span>出入库明细</span>
                         </el-menu-item>
+                        <el-menu-item index="17" @click="handleMenuClick(17)">
+                            <span>采购订单信息</span>
+                        </el-menu-item>
                         <el-menu-item index="5" @click="handleMenuClick(5)">
                             <span>库存</span>
                         </el-menu-item>
@@ -95,6 +98,7 @@ import MaterialManagementView from '@/Pages/LogisticsControlDepartment/Logistics
 import SupplierManagement from '@/Pages/LogisticsControlDepartment/LogisticsControlManager/components/SupplierManagementView.vue'
 import FinancialWarehouseDetail from '@/Pages/FinancialManager/components/FinancialWarehouseDetail.vue'
 import MakeInventory from '../components/MakeInventory.vue'
+import PurchaseOrderInfo from '../components/PurchaseOrderInfo.vue'
 
 export default {
     components: {
@@ -116,7 +120,8 @@ export default {
         MaterialManagementView,
         SupplierManagement,
         FinancialWarehouseDetail,
-        MakeInventory
+        MakeInventory,
+        PurchaseOrderInfo
     },
     data() {
         return {
@@ -181,6 +186,9 @@ export default {
                     break
                 case 16:
                     this.currentComponent = 'FinancialWarehouseDetail'
+                    break
+                case 17:
+                    this.currentComponent = 'PurchaseOrderInfo'
                     break
             }
         }


### PR DESCRIPTION
1.将文员查询采购订单页面添加至总仓/物控主页面
2.为查询添加库存实际数量及入库数量
3.因表过大，微调查询数据库逻辑